### PR TITLE
refactor: implement string view to replace string structs

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -15,8 +15,8 @@ SNUK_INLINE char *copy_string(const char *str, uint64_t length) {
 SNUK_INLINE SnukIdentifier copy_identifier(SnukExpr *identifier) {
     SNUK_ASSERT(identifier->type == SNUK_EXPR_IDENTIFIER, "not identifier");
     SnukIdentifier ident = {
-        .name = copy_string(identifier->identifier.name, identifier->identifier.length),
-        .length = identifier->identifier.length,
+        .name = copy_string(identifier->identifier.str, identifier->identifier.len),
+        .length = identifier->identifier.len,
     };
     return ident;
 }
@@ -102,8 +102,8 @@ Value snuk_interpreter_eval_expr(SnukInterpreter *i, SnukExpr *expr) {
             return (Value){
                 .type = VALUE_STRING, 
                 .string_value = {
-                    .string = copy_string(expr->string_literal.value, expr->string_literal.length),
-                    .length = expr->string_literal.length,
+                    .string = copy_string(expr->string_literal.str, expr->string_literal.len),
+                    .length = expr->string_literal.len,
                 },
             };
 
@@ -144,9 +144,9 @@ Value snuk_interpreter_eval_expr(SnukInterpreter *i, SnukExpr *expr) {
 }
 
 static Value get_identifier_value(SnukInterpreter *i, SnukExpr *identifier) {
-    SNUK_ASSERT(identifier->identifier.length > 0, "identifier name is empty");
+    SNUK_ASSERT(identifier->identifier.len > 0, "identifier name is empty");
 
-    uint64_t index = (uint64_t)identifier->identifier.name[0];
+    uint64_t index = (uint64_t)identifier->identifier.str[0];
     uint64_t length = snuk_darray_get_length(i->envs);
 
     if (length < index) goto fail;
@@ -154,9 +154,9 @@ static Value get_identifier_value(SnukInterpreter *i, SnukExpr *identifier) {
 
     uint64_t count = snuk_darray_get_length(i->envs[index]);
     for (uint64_t j = 0; j < count; ++j) {
-        if (identifier->identifier.length != i->envs[index][j].identifier.length) continue;
-        if (string_n_equal(identifier->identifier.name,
-                    i->envs[index][j].identifier.name, identifier->identifier.length)) {
+        if (identifier->identifier.len != i->envs[index][j].identifier.length) continue;
+        if (string_n_equal(identifier->identifier.str,
+                    i->envs[index][j].identifier.name, identifier->identifier.len)) {
             return i->envs[index][j].value;
         }
     }
@@ -166,10 +166,10 @@ fail:
 }
 
 static Value set_identifier_value(SnukInterpreter *i, SnukExpr *identifier, SnukExpr *expr) {
-    SNUK_ASSERT(identifier->identifier.length > 0, "identifier name is empty");
+    SNUK_ASSERT(identifier->identifier.len > 0, "identifier name is empty");
 
     Value value = snuk_interpreter_eval_expr(i, expr);
-    uint64_t index = (uint64_t)identifier->identifier.name[0];
+    uint64_t index = (uint64_t)identifier->identifier.str[0];
     uint64_t length = snuk_darray_get_length(i->envs);
 
     if (length < index) goto fail;
@@ -177,9 +177,9 @@ static Value set_identifier_value(SnukInterpreter *i, SnukExpr *identifier, Snuk
 
     uint64_t count = snuk_darray_get_length(i->envs[index]);
     for (uint64_t j = 0; j < count; ++j) {
-        if (identifier->identifier.length != i->envs[index][j].identifier.length) continue;
-        if (string_n_equal(identifier->identifier.name,
-                    i->envs[index][j].identifier.name, identifier->identifier.length)) {
+        if (identifier->identifier.len != i->envs[index][j].identifier.length) continue;
+        if (string_n_equal(identifier->identifier.str,
+                    i->envs[index][j].identifier.name, identifier->identifier.len)) {
             i->envs[index][j].value = value;
             return value;
         }
@@ -310,7 +310,7 @@ static void add_identifier(SnukInterpreter *i, SnukExpr *identifier, SnukExpr *e
     // TODO: multiple declaration errors
 
     Value value = snuk_interpreter_eval_expr(i, expr);
-    uint64_t index = (uint64_t)identifier->identifier.name[0];
+    uint64_t index = (uint64_t)identifier->identifier.str[0];
     uint64_t length = snuk_darray_get_length(i->envs);
 
     if (length < index)

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -12,13 +12,11 @@ SNUK_INLINE char *copy_string(const char *str, uint64_t length) {
     return copy;
 }
 
-SNUK_INLINE SnukIdentifier copy_identifier(SnukExpr *identifier) {
+SNUK_INLINE SnukStringView copy_identifier(SnukExpr *identifier) {
     SNUK_ASSERT(identifier->type == SNUK_EXPR_IDENTIFIER, "not identifier");
-    SnukIdentifier ident = {
-        .name = copy_string(identifier->identifier.str, identifier->identifier.len),
-        .length = identifier->identifier.len,
-    };
-    return ident;
+    return snuk_string_view_create_with_len(
+            copy_string(identifier->identifier.str, identifier->identifier.len),
+            identifier->identifier.len);
 }
 
 static Value get_identifier_value(SnukInterpreter *i, SnukExpr *identifier);
@@ -101,10 +99,9 @@ Value snuk_interpreter_eval_expr(SnukInterpreter *i, SnukExpr *expr) {
         case SNUK_EXPR_STRING_LITERAL:
             return (Value){
                 .type = VALUE_STRING, 
-                .string_value = {
-                    .string = copy_string(expr->string_literal.str, expr->string_literal.len),
-                    .length = expr->string_literal.len,
-                },
+                .string_value = snuk_string_view_create_with_len(
+                        copy_string(expr->string_literal.str, expr->string_literal.len),
+                        expr->string_literal.len),
             };
 
         case SNUK_EXPR_TRUE_LITERAL:
@@ -154,9 +151,9 @@ static Value get_identifier_value(SnukInterpreter *i, SnukExpr *identifier) {
 
     uint64_t count = snuk_darray_get_length(i->envs[index]);
     for (uint64_t j = 0; j < count; ++j) {
-        if (identifier->identifier.len != i->envs[index][j].identifier.length) continue;
+        if (identifier->identifier.len != i->envs[index][j].identifier.len) continue;
         if (string_n_equal(identifier->identifier.str,
-                    i->envs[index][j].identifier.name, identifier->identifier.len)) {
+                    i->envs[index][j].identifier.str, identifier->identifier.len)) {
             return i->envs[index][j].value;
         }
     }
@@ -177,9 +174,9 @@ static Value set_identifier_value(SnukInterpreter *i, SnukExpr *identifier, Snuk
 
     uint64_t count = snuk_darray_get_length(i->envs[index]);
     for (uint64_t j = 0; j < count; ++j) {
-        if (identifier->identifier.len != i->envs[index][j].identifier.length) continue;
+        if (identifier->identifier.len != i->envs[index][j].identifier.len) continue;
         if (string_n_equal(identifier->identifier.str,
-                    i->envs[index][j].identifier.name, identifier->identifier.len)) {
+                    i->envs[index][j].identifier.str, identifier->identifier.len)) {
             i->envs[index][j].value = value;
             return value;
         }
@@ -355,7 +352,7 @@ void snuk_interpreter_print_value(Value value) {
             break;
         case VALUE_STRING:
             snuk_println("type: %s", SNUK_STRINGIFY(VALUE_STRING));
-            snuk_println("value: %.*s", value.string_value.length, value.string_value.string);
+            snuk_println("value: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(value.string_value));
             break;
         case VALUE_NULL:
             snuk_println("type: %s", SNUK_STRINGIFY(VALUE_NULL));

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -5,20 +5,6 @@
 #include "snuk_string.h"
 #include "io.h"
 
-SNUK_INLINE char *copy_string(const char *str, uint64_t length) {
-    char *copy = snuk_alloc(sizeof(char) * (length + 1), alignof(char));
-    memcpy(copy, str, length);
-    copy[length] = 0;
-    return copy;
-}
-
-SNUK_INLINE SnukStringView copy_identifier(SnukExpr *identifier) {
-    SNUK_ASSERT(identifier->type == SNUK_EXPR_IDENTIFIER, "not identifier");
-    return snuk_string_view_create_with_len(
-            copy_string(identifier->identifier.str, identifier->identifier.len),
-            identifier->identifier.len);
-}
-
 static Value get_identifier_value(SnukInterpreter *i, SnukExpr *identifier);
 static Value set_identifier_value(SnukInterpreter *i, SnukExpr *identifier, SnukExpr *value);
 
@@ -99,9 +85,7 @@ Value snuk_interpreter_eval_expr(SnukInterpreter *i, SnukExpr *expr) {
         case SNUK_EXPR_STRING_LITERAL:
             return (Value){
                 .type = VALUE_STRING, 
-                .string_value = snuk_string_view_create_with_len(
-                        copy_string(expr->string_literal.str, expr->string_literal.len),
-                        expr->string_literal.len),
+                .string_value = snuk_string_view_copy(expr->string_literal),
             };
 
         case SNUK_EXPR_TRUE_LITERAL:
@@ -316,7 +300,7 @@ static void add_identifier(SnukInterpreter *i, SnukExpr *identifier, SnukExpr *e
         i->envs[index] = snuk_darray_create(Env);
 
     Env env = {
-        .identifier = copy_identifier(identifier),
+        .identifier = snuk_string_view_copy(identifier->identifier),
         .value = value,
     };
     snuk_darray_push(&i->envs[index], env);

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -4,6 +4,7 @@
 #include "darray.h"
 
 #include "parser.h"
+#include "string_view.h"
 
 typedef struct Value {
     enum {
@@ -19,20 +20,12 @@ typedef struct Value {
         int64_t int_value;
         double float_value;
         bool bool_value;
-        struct { 
-            const char *string;
-            uint64_t length;
-        } string_value;
+        SnukStringView string_value;
     };
 } Value;
 
-typedef struct SnukIdentifier{
-    const char *name;
-    uint64_t length;
-} SnukIdentifier;
-
 typedef struct Env {
-    SnukIdentifier identifier;
+    SnukStringView identifier;
     Value value;
 } Env;
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -7,48 +7,46 @@
 #include <stdlib.h>
 
 typedef struct KeyWord {
-    const char *str;
-    uint64_t len;
+    SnukStringView keyword;
     SnukTokenType type;
 } KeyWord;
 
 typedef struct Value {
-    const char *str;
-    uint64_t len;
+    SnukStringView value;
     SnukTokenType type;
     bool ignore_case;
 } Value;
 
 KeyWord keywords[] = {
-    {.str = "var",      .len = 3, .type = SNUK_TOKEN_VAR},
-    {.str = "const",    .len = 5, .type = SNUK_TOKEN_CONST},
-    {.str = "if",       .len = 2, .type = SNUK_TOKEN_IF},
-    {.str = "else",     .len = 4, .type = SNUK_TOKEN_ELSE},
-    {.str = "match",    .len = 5, .type = SNUK_TOKEN_MATCH},
-    {.str = "case",     .len = 4, .type = SNUK_TOKEN_CASE},
-    {.str = "while",    .len = 5, .type = SNUK_TOKEN_WHILE},
-    {.str = "do",       .len = 2, .type = SNUK_TOKEN_DO},
-    {.str = "for",      .len = 3, .type = SNUK_TOKEN_FOR},
-    {.str = "return",   .len = 6, .type = SNUK_TOKEN_RETURN},
-    {.str = "break",    .len = 5, .type = SNUK_TOKEN_BREAK},
-    {.str = "continue", .len = 8, .type = SNUK_TOKEN_CONTINUE},
-    {.str = "fn",       .len = 2, .type = SNUK_TOKEN_FN},
-    {.str = "print",    .len = 5, .type = SNUK_TOKEN_PRINT},
-    {.str = "self",     .len = 4, .type = SNUK_TOKEN_SELF},
-    {.str = "type",     .len = 4, .type = SNUK_TOKEN_TYPE},
-    {.str = "or",       .len = 2, .type = SNUK_TOKEN_LOGICAL_OR},
-    {.str = "and",      .len = 3, .type = SNUK_TOKEN_LOGICAL_AND},
-    {.str = "not",      .len = 3, .type = SNUK_TOKEN_BANG},
+    {.keyword = {.str = "var",      .len = 3}, .type = SNUK_TOKEN_VAR},
+    {.keyword = {.str = "const",    .len = 5}, .type = SNUK_TOKEN_CONST},
+    {.keyword = {.str = "if",       .len = 2}, .type = SNUK_TOKEN_IF},
+    {.keyword = {.str = "else",     .len = 4}, .type = SNUK_TOKEN_ELSE},
+    {.keyword = {.str = "match",    .len = 5}, .type = SNUK_TOKEN_MATCH},
+    {.keyword = {.str = "case",     .len = 4}, .type = SNUK_TOKEN_CASE},
+    {.keyword = {.str = "while",    .len = 5}, .type = SNUK_TOKEN_WHILE},
+    {.keyword = {.str = "do",       .len = 2}, .type = SNUK_TOKEN_DO},
+    {.keyword = {.str = "for",      .len = 3}, .type = SNUK_TOKEN_FOR},
+    {.keyword = {.str = "return",   .len = 6}, .type = SNUK_TOKEN_RETURN},
+    {.keyword = {.str = "break",    .len = 5}, .type = SNUK_TOKEN_BREAK},
+    {.keyword = {.str = "continue", .len = 8}, .type = SNUK_TOKEN_CONTINUE},
+    {.keyword = {.str = "fn",       .len = 2}, .type = SNUK_TOKEN_FN},
+    {.keyword = {.str = "print",    .len = 5}, .type = SNUK_TOKEN_PRINT},
+    {.keyword = {.str = "self",     .len = 4}, .type = SNUK_TOKEN_SELF},
+    {.keyword = {.str = "type",     .len = 4}, .type = SNUK_TOKEN_TYPE},
+    {.keyword = {.str = "or",       .len = 2}, .type = SNUK_TOKEN_LOGICAL_OR},
+    {.keyword = {.str = "and",      .len = 3}, .type = SNUK_TOKEN_LOGICAL_AND},
+    {.keyword = {.str = "not",      .len = 3}, .type = SNUK_TOKEN_BANG},
 };
 
 Value values[] = {
-    {.str = "true",     .len = 4, .type = SNUK_TOKEN_TRUE,  .ignore_case = false},
-    {.str = "false",    .len = 5, .type = SNUK_TOKEN_FALSE, .ignore_case = false},
-    {.str = "null",     .len = 4, .type = SNUK_TOKEN_NULL,  .ignore_case = false},
+    {.value = {.str = "true",     .len = 4}, .type = SNUK_TOKEN_TRUE,  .ignore_case = false},
+    {.value = {.str = "false",    .len = 5}, .type = SNUK_TOKEN_FALSE, .ignore_case = false},
+    {.value = {.str = "null",     .len = 4}, .type = SNUK_TOKEN_NULL,  .ignore_case = false},
 
-    {.str = "nan",      .len = 3, .type = SNUK_TOKEN_NAN,   .ignore_case = true},
-    {.str = "inf",      .len = 3, .type = SNUK_TOKEN_INF,   .ignore_case = true},
-    {.str = "infinity", .len = 8, .type = SNUK_TOKEN_INF,   .ignore_case = true},
+    {.value = {.str = "nan",      .len = 3}, .type = SNUK_TOKEN_NAN,   .ignore_case = true},
+    {.value = {.str = "inf",      .len = 3}, .type = SNUK_TOKEN_INF,   .ignore_case = true},
+    {.value = {.str = "infinity", .len = 8}, .type = SNUK_TOKEN_INF,   .ignore_case = true},
 };
 
 SNUK_INLINE bool lexer_is_eof(SnukLexer *lexer) {
@@ -95,7 +93,7 @@ SNUK_INLINE SnukToken lexer_build_token(SnukLexer *lexer, SnukTokenType type) {
     uint64_t len = lexer->cur - lexer->token_start;
     return (SnukToken){
         .type = type,
-        .string_literal = {.value = lexer->token_start, .length = len},
+        .string_literal = snuk_string_view_create_with_len(lexer->token_start, len),
         .line = lexer->token_start_line,
         .col = lexer->token_start_col,
         .err_msg = NULL,
@@ -109,7 +107,7 @@ SNUK_INLINE SnukToken lexer_build_error_token(SnukLexer *lexer, const char *err_
 
     return (SnukToken) {
         .type = SNUK_TOKEN_ERROR,
-        .string_literal = {.value = line_start, .length = len},
+        .string_literal = snuk_string_view_create_with_len(line_start, len),
         .line = lexer->line,
         .col = lexer->col,
         .err_msg = err_msg,
@@ -262,9 +260,9 @@ static SnukToken lexer_scan_string(SnukLexer *lexer, char quote) {
 
 static SnukTokenType check_keyword(const char *s, uint64_t len) {
     for (uint64_t i = 0; i < ARRAY_LEN(keywords); ++i) {
-        if (len != keywords[i].len) continue;
+        if (len != keywords[i].keyword.len) continue;
 
-        if (string_n_equal(s, keywords[i].str, keywords[i].len))
+        if (string_n_equal(s, keywords[i].keyword.str, keywords[i].keyword.len))
             return keywords[i].type;
     }
     return SNUK_TOKEN_EOF;
@@ -272,11 +270,11 @@ static SnukTokenType check_keyword(const char *s, uint64_t len) {
 
 static SnukTokenType check_values(const char *s, uint64_t len) {
     for (uint64_t i = 0; i < ARRAY_LEN(values); ++i) {
-        if (len != values[i].len) continue;
+        if (len != values[i].value.len) continue;
 
-        if (values[i].ignore_case && string_n_equal_ignore_case(s, values[i].str, values[i].len))
+        if (values[i].ignore_case && string_n_equal_ignore_case(s, values[i].value.str, values[i].value.len))
             return values[i].type;
-        else if (string_n_equal(s, values[i].str, values[i].len))
+        else if (string_n_equal(s, values[i].value.str, values[i].value.len))
             return values[i].type;
     }
 
@@ -419,9 +417,9 @@ void snuk_lexer_log_token(SnukToken token) {
         log_trace("\tFloat value: %lf", token.float_literal);
     else if (token.type == SNUK_TOKEN_ERROR)
         log_trace("\tError line: %.*s and err_msg: %s",
-                token.string_literal.length, token.string_literal.value, token.err_msg);
+                token.string_literal.len, token.string_literal.str, token.err_msg);
     else
-        log_trace("\tString value: %.*s", token.string_literal.length, token.string_literal.value);
+        log_trace("\tString value: %.*s", token.string_literal.len, token.string_literal.str);
     log_trace("\tLine: %d, Column: %d", token.line, token.col);
 }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -416,10 +416,10 @@ void snuk_lexer_log_token(SnukToken token) {
     else if (token.type == SNUK_TOKEN_FLOAT)
         log_trace("\tFloat value: %lf", token.float_literal);
     else if (token.type == SNUK_TOKEN_ERROR)
-        log_trace("\tError line: %.*s and err_msg: %s",
-                token.string_literal.len, token.string_literal.str, token.err_msg);
+        log_trace("\tError line: "SNUK_STRING_VIEW_FORMAT" and err_msg: %s",
+                SNUK_STRING_VIEW_ARG(token.string_literal), token.err_msg);
     else
-        log_trace("\tString value: %.*s", token.string_literal.len, token.string_literal.str);
+        log_trace("\tString value: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(token.string_literal));
     log_trace("\tLine: %d, Column: %d", token.line, token.col);
 }
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -2,6 +2,8 @@
 
 #include "defines.h"
 
+#include "string_view.h"
+
 SNUK_STATIC_ASSERT(sizeof(double) == 8, "Expected sizeof(double) to be 8 bytes.");
 
 typedef enum SnukTokenType {
@@ -107,10 +109,7 @@ typedef enum SnukTokenType {
 typedef struct SnukToken {
     SnukTokenType type;
     union {
-        struct {
-            const char *value;
-            uint64_t length;
-        } string_literal;
+        SnukStringView string_literal;
         int64_t int_literal;
         double float_literal;
     };

--- a/src/parser.c
+++ b/src/parser.c
@@ -443,10 +443,10 @@ void snuk_parser_log_stmt(SnukStmt *stmt) {
                 snuk_parser_log_stmt(stmt->block_stmt.stmts[i]);
             break;
         case SNUK_STMT_SLCOMMENT:
-            log_trace("single line comment: %.*s", stmt->comment_stmt.length, stmt->comment_stmt.comment);
+            log_trace("single line comment: %.*s", stmt->comment.len, stmt->comment.str);
             break;
         case SNUK_STMT_MLCOMMENT:
-            log_trace("multi-line comment: %.*s", stmt->comment_stmt.length, stmt->comment_stmt.comment);
+            log_trace("multi-line comment: %.*s", stmt->comment.len, stmt->comment.str);
             break;
         default:
             break;
@@ -459,7 +459,7 @@ void snuk_parser_log_expr(SnukExpr *expr) {
 
     switch (expr->type) {
         case SNUK_EXPR_IDENTIFIER:
-            log_trace("Identifier: %.*s", expr->identifier.length, expr->identifier.name);
+            log_trace("Identifier: %.*s", expr->identifier.len, expr->identifier.str);
             break;
         case SNUK_EXPR_INT_LITERAL:
             log_trace("Integer: %ld", expr->int_literal);
@@ -468,7 +468,7 @@ void snuk_parser_log_expr(SnukExpr *expr) {
             log_trace("Float: %lf", expr->float_literal);
             break;
         case SNUK_EXPR_STRING_LITERAL:
-            log_trace("String: %.*s", expr->string_literal.length, expr->string_literal.value);
+            log_trace("String: %.*s", expr->string_literal.len, expr->string_literal.str);
             break;
         case SNUK_EXPR_TRUE_LITERAL:
         case SNUK_EXPR_FALSE_LITERAL:
@@ -489,7 +489,7 @@ void snuk_parser_log_expr(SnukExpr *expr) {
             snuk_parser_log_expr(expr->binary.right);
             break;
         case SNUK_EXPR_CALL:
-            log_trace("call: %.*s", expr->identifier.length, expr->identifier.name);
+            log_trace("call: %.*s", expr->identifier.len, expr->identifier.str);
             break;
         case SNUK_EXPR_MEMBER:
             log_trace("Member:", NULL);

--- a/src/parser.c
+++ b/src/parser.c
@@ -319,7 +319,7 @@ static void parser_error(SnukParser *parser, const char *err_msg) {
     SnukToken t = parser->current;
     snuk_eprint("%lu:%lu error", t.line, t.col);
     if (t.type == SNUK_TOKEN_EOF) snuk_eprint(" at end");
-    else snuk_eprint(" at '%.*s'", t.string_literal.len, t.string_literal.str);
+    else snuk_eprint(" at '"SNUK_STRING_VIEW_FORMAT"'", SNUK_STRING_VIEW_ARG(t.string_literal));
     snuk_eprintln(" at '%s", err_msg);
 }
 
@@ -443,10 +443,10 @@ void snuk_parser_log_stmt(SnukStmt *stmt) {
                 snuk_parser_log_stmt(stmt->block_stmt.stmts[i]);
             break;
         case SNUK_STMT_SLCOMMENT:
-            log_trace("single line comment: %.*s", stmt->comment.len, stmt->comment.str);
+            log_trace("single line comment: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(stmt->comment));
             break;
         case SNUK_STMT_MLCOMMENT:
-            log_trace("multi-line comment: %.*s", stmt->comment.len, stmt->comment.str);
+            log_trace("multi-line comment: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(stmt->comment));
             break;
         default:
             break;
@@ -459,7 +459,7 @@ void snuk_parser_log_expr(SnukExpr *expr) {
 
     switch (expr->type) {
         case SNUK_EXPR_IDENTIFIER:
-            log_trace("Identifier: %.*s", expr->identifier.len, expr->identifier.str);
+            log_trace("Identifier: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(expr->identifier));
             break;
         case SNUK_EXPR_INT_LITERAL:
             log_trace("Integer: %ld", expr->int_literal);
@@ -468,7 +468,7 @@ void snuk_parser_log_expr(SnukExpr *expr) {
             log_trace("Float: %lf", expr->float_literal);
             break;
         case SNUK_EXPR_STRING_LITERAL:
-            log_trace("String: %.*s", expr->string_literal.len, expr->string_literal.str);
+            log_trace("String: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(expr->string_literal));
             break;
         case SNUK_EXPR_TRUE_LITERAL:
         case SNUK_EXPR_FALSE_LITERAL:
@@ -489,7 +489,7 @@ void snuk_parser_log_expr(SnukExpr *expr) {
             snuk_parser_log_expr(expr->binary.right);
             break;
         case SNUK_EXPR_CALL:
-            log_trace("call: %.*s", expr->identifier.len, expr->identifier.str);
+            log_trace("call: "SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(expr->identifier));
             break;
         case SNUK_EXPR_MEMBER:
             log_trace("Member:", NULL);

--- a/src/parser.c
+++ b/src/parser.c
@@ -319,7 +319,7 @@ static void parser_error(SnukParser *parser, const char *err_msg) {
     SnukToken t = parser->current;
     snuk_eprint("%lu:%lu error", t.line, t.col);
     if (t.type == SNUK_TOKEN_EOF) snuk_eprint(" at end");
-    else snuk_eprint(" at '%.*s'", t.string_literal.length, t.string_literal.value);
+    else snuk_eprint(" at '%.*s'", t.string_literal.len, t.string_literal.str);
     snuk_eprintln(" at '%s", err_msg);
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -3,6 +3,7 @@
 #include "defines.h"
 
 #include "lexer.h"
+#include "string_view.h"
 
 typedef enum SnukStmtType {
     SNUK_STMT_EXPR,
@@ -61,19 +62,10 @@ struct SnukExpr {
     SnukExprType type;
 
     union {
-        struct {
-            const char *value;
-            uint64_t length;
-        } string_literal;
-
+        SnukStringView string_literal;
         int64_t int_literal;
-
         double float_literal;
-
-        struct {
-            const char *name;
-            uint64_t length;
-        } identifier;
+        SnukStringView identifier;
 
         struct {
             SnukTokenType op;
@@ -162,10 +154,7 @@ struct SnukStmt {
             SnukStmt **stmts; // darray
         } block_stmt;
 
-        struct {
-            const char *comment;
-            uint64_t length;
-        } comment_stmt;
+        SnukStringView comment;
     };
 };
 

--- a/src/parser_helper.h
+++ b/src/parser_helper.h
@@ -255,10 +255,7 @@ SNUK_INLINE SnukStmt *build_comment_stmt(SnukParser *parser, SnukToken comment_t
     SnukStmt *comment_stmt = parser_create_stmt(parser);
     *comment_stmt = (SnukStmt){
         .type = comment_token.type == SNUK_TOKEN_MLCOMMENT ? SNUK_STMT_MLCOMMENT : SNUK_STMT_SLCOMMENT,
-        .comment_stmt = {
-            .comment = comment_token.string_literal.str,
-            .length = comment_token.string_literal.len,
-        },
+        .comment = comment_token.string_literal,
     };
     return comment_stmt;
 }
@@ -284,10 +281,7 @@ SNUK_INLINE SnukExpr *build_string_literal_expr(SnukParser *parser) {
     SnukExpr *string_expr = parser_create_expr(parser);
     *string_expr = (SnukExpr){
         .type = SNUK_EXPR_STRING_LITERAL,
-        .string_literal = {
-            .value = parser->previous.string_literal.str,
-            .length = parser->previous.string_literal.len,
-        },
+        .string_literal = parser->previous.string_literal,
     };
     return string_expr;
 }
@@ -296,10 +290,7 @@ SNUK_INLINE SnukExpr *build_identifier_expr(SnukParser *parser) {
     SnukExpr *identifier = parser_create_expr(parser);
     *identifier = (SnukExpr){
         .type = SNUK_EXPR_IDENTIFIER,
-        .identifier = {
-            .name = parser->previous.string_literal.str,
-            .length = parser->previous.string_literal.len,
-        },
+        .identifier = parser->previous.string_literal,
     };
     return identifier;
 }

--- a/src/parser_helper.h
+++ b/src/parser_helper.h
@@ -256,8 +256,8 @@ SNUK_INLINE SnukStmt *build_comment_stmt(SnukParser *parser, SnukToken comment_t
     *comment_stmt = (SnukStmt){
         .type = comment_token.type == SNUK_TOKEN_MLCOMMENT ? SNUK_STMT_MLCOMMENT : SNUK_STMT_SLCOMMENT,
         .comment_stmt = {
-            .comment = comment_token.string_literal.value,
-            .length = comment_token.string_literal.length,
+            .comment = comment_token.string_literal.str,
+            .length = comment_token.string_literal.len,
         },
     };
     return comment_stmt;
@@ -285,8 +285,8 @@ SNUK_INLINE SnukExpr *build_string_literal_expr(SnukParser *parser) {
     *string_expr = (SnukExpr){
         .type = SNUK_EXPR_STRING_LITERAL,
         .string_literal = {
-            .value = parser->previous.string_literal.value,
-            .length = parser->previous.string_literal.length,
+            .value = parser->previous.string_literal.str,
+            .length = parser->previous.string_literal.len,
         },
     };
     return string_expr;
@@ -297,8 +297,8 @@ SNUK_INLINE SnukExpr *build_identifier_expr(SnukParser *parser) {
     *identifier = (SnukExpr){
         .type = SNUK_EXPR_IDENTIFIER,
         .identifier = {
-            .name = parser->previous.string_literal.value,
-            .length = parser->previous.string_literal.length,
+            .name = parser->previous.string_literal.str,
+            .length = parser->previous.string_literal.len,
         },
     };
     return identifier;

--- a/src/string_view.h
+++ b/src/string_view.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "defines.h"
+
+#include "snuk_string.h"
+#include "memory.h"
+#include <string.h>
+
+typedef struct SnukStringView {
+    const char *str;
+    uint64_t len;
+} SnukStringView;
+
+SNUK_INLINE SnukStringView snuk_string_view_create_with_len(const char *str, uint64_t len) {
+    return (SnukStringView){
+        .str = str,
+        .len = len,
+    };
+}
+
+SNUK_INLINE SnukStringView snuk_string_view_create(const char *str) {
+    return snuk_string_view_create_with_len(str, string_length(str));
+}
+
+SNUK_INLINE char *snuk_string_view_get_cstr(SnukStringView view) {
+    char *str = snuk_alloc((view.len + 1) * sizeof(char), alignof(char));
+    memcpy(str, view.str, view.len);
+    str[view.len] = 0;
+    return str;
+}

--- a/src/string_view.h
+++ b/src/string_view.h
@@ -6,6 +6,9 @@
 #include "memory.h"
 #include <string.h>
 
+#define SNUK_STRING_VIEW_FORMAT "%.*s"
+#define SNUK_STRING_VIEW_ARG(sv) (sv).len, (sv).str
+
 typedef struct SnukStringView {
     const char *str;
     uint64_t len;

--- a/src/string_view.h
+++ b/src/string_view.h
@@ -31,3 +31,13 @@ SNUK_INLINE char *snuk_string_view_get_cstr(SnukStringView view) {
     str[view.len] = 0;
     return str;
 }
+
+SNUK_INLINE SnukStringView snuk_string_view_copy(SnukStringView view) {
+    char *str = snuk_alloc(sizeof(char) * view.len, alignof(char)); 
+    memcpy(str, view.str, view.len);
+
+    return (SnukStringView){
+        .str = str,
+        .len = view.len,
+    };
+}


### PR DESCRIPTION
## What does this PR do?
Implement `SnukStringView` and utility functions
Refactor inline string structs to use SnukStringView

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation
- [x] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [ ] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [ ] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?
Closes #4

Known bugs:
Memory leaks: interpreter never frees the copied string views.