### PR TITLE
docs(lexer): add Doxygen documentation comments

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -51,19 +51,49 @@ Value values[] = {
     {.value = {.str = "infinity", .len = 8}, .type = SNUK_TOKEN_INF,   .ignore_case = true},
 };
 
+/**
+ * @brief Check whether the lexer cursor is at the end of the source.
+ *
+ * @param lexer Lexer state to inspect.
+ *
+ * @return True when the cursor points at the null terminator.
+ */
 SNUK_INLINE bool lexer_is_eof(SnukLexer *lexer) {
     return *lexer->cur == '\0';
 }
 
+/**
+ * @brief Read the current source character without advancing.
+ *
+ * @param lexer Lexer state to inspect.
+ *
+ * @return The current source character.
+ */
 SNUK_INLINE char lexer_peek(SnukLexer *lexer) {
     return *lexer->cur;
 }
 
+/**
+ * @brief Read the next source character without advancing.
+ *
+ * @param lexer Lexer state to inspect.
+ *
+ * @return The next source character, or '\0' when already at EOF.
+ */
 SNUK_INLINE char lexer_peek_next(SnukLexer *lexer) {
     if (lexer_is_eof(lexer)) return '\0';
     return *(lexer->cur + 1);
 }
 
+/**
+ * @brief Consume the current source character and update cursor position.
+ *
+ * @param lexer Lexer state to advance.
+ *
+ * @return The consumed character, or '\0' when already at EOF.
+ *
+ * @note Newlines increment the line counter and reset the column to zero.
+ */
 SNUK_INLINE char lexer_advance(SnukLexer *lexer) {
     if (lexer_is_eof(lexer)) return '\0';
 
@@ -81,16 +111,37 @@ SNUK_INLINE char lexer_advance(SnukLexer *lexer) {
     return c;
 }
 
+/**
+ * @brief Consume the expected character when it is next in the source.
+ *
+ * @param lexer Lexer state to inspect and possibly advance.
+ * @param expected Character to match.
+ *
+ * @return True when the expected character was consumed.
+ */
 SNUK_INLINE bool lexer_match(SnukLexer *lexer, char expected) {
     if (lexer_peek(lexer) != expected) return false;
     lexer_advance(lexer);
     return true;
 }
 
+/**
+ * @brief Consume whitespace before the next token.
+ *
+ * @param lexer Lexer state to advance.
+ */
 SNUK_INLINE void lexer_skip_white_spaces(SnukLexer *lexer) {
     while (char_in_string(lexer_peek(lexer), " \t\r\n")) lexer_advance(lexer);
 }
 
+/**
+ * @brief Build a token spanning from token_start to the current cursor.
+ *
+ * @param lexer Lexer state containing the token bounds.
+ * @param type Token type to assign.
+ *
+ * @return Token with a source slice and starting position.
+ */
 SNUK_INLINE SnukToken lexer_build_token(SnukLexer *lexer, SnukTokenType type) {
     uint64_t len = lexer->cur - lexer->token_start;
     return (SnukToken){
@@ -102,6 +153,14 @@ SNUK_INLINE SnukToken lexer_build_token(SnukLexer *lexer, SnukTokenType type) {
     };
 }
 
+/**
+ * @brief Build an error token for the current source line.
+ *
+ * @param lexer Lexer state at the error location.
+ * @param err_msg Static error message describing the failure.
+ *
+ * @return Error token containing the current line text and location.
+ */
 SNUK_INLINE SnukToken lexer_build_error_token(SnukLexer *lexer, const char *err_msg) {
     const char *line_start = lexer->cur - lexer->col;
     uint64_t len = 0;
@@ -123,6 +182,13 @@ static SnukToken lexer_scan_number(SnukLexer *lexer);
 static SnukToken lexer_scan_string(SnukLexer *lexer, char quote);
 static SnukToken lexer_scan_comment(SnukLexer *lexer, bool multi_line);
 
+/**
+ * @brief Scan an identifier-like word and classify keywords or literal values.
+ *
+ * @param lexer Lexer state positioned at the first word character.
+ *
+ * @return Identifier, keyword, or value token.
+ */
 static SnukToken lexer_scan_word(SnukLexer *lexer) {
     // assumes the first character is valid for identifier
     lexer->token_start = lexer->cur;
@@ -146,6 +212,14 @@ static SnukToken lexer_scan_word(SnukLexer *lexer) {
     return lexer_build_token(lexer, SNUK_TOKEN_IDENTIFIER);
 }
 
+/**
+ * @brief Scan an integer or floating-point numeric literal.
+ *
+ * @param lexer Lexer state positioned at the first numeric character or a
+ * leading decimal point.
+ *
+ * @return Integer, float, or error token.
+ */
 static SnukToken lexer_scan_number(SnukLexer *lexer) {
     lexer->token_start = lexer->cur;
     lexer->token_start_line = lexer->line;
@@ -247,6 +321,16 @@ static SnukToken lexer_scan_number(SnukLexer *lexer) {
     return token;
 }
 
+/**
+ * @brief Scan a quoted string literal.
+ *
+ * @param lexer Lexer state positioned after the opening quote.
+ * @param quote Quote character that terminates the string.
+ *
+ * @return String or error token.
+ *
+ * @note The caller must have already consumed the opening quote.
+ */
 static SnukToken lexer_scan_string(SnukLexer *lexer, char quote) {
     // starting quote is consumed
 
@@ -260,6 +344,14 @@ static SnukToken lexer_scan_string(SnukLexer *lexer, char quote) {
     return lexer_build_token(lexer, SNUK_TOKEN_STRING);
 }
 
+/**
+ * @brief Check whether a word is a reserved keyword.
+ *
+ * @param s Start of the word.
+ * @param len Length of the word.
+ *
+ * @return Keyword token type, or SNUK_TOKEN_EOF when the word is not a keyword.
+ */
 static SnukTokenType check_keyword(const char *s, uint64_t len) {
     for (uint64_t i = 0; i < ARRAY_LEN(keywords); ++i) {
         if (len != keywords[i].keyword.len) continue;
@@ -270,6 +362,14 @@ static SnukTokenType check_keyword(const char *s, uint64_t len) {
     return SNUK_TOKEN_EOF;
 }
 
+/**
+ * @brief Check whether a word is a built-in literal value.
+ *
+ * @param s Start of the word.
+ * @param len Length of the word.
+ *
+ * @return Value token type, or SNUK_TOKEN_EOF when the word is not a value.
+ */
 static SnukTokenType check_values(const char *s, uint64_t len) {
     for (uint64_t i = 0; i < ARRAY_LEN(values); ++i) {
         if (len != values[i].value.len) continue;
@@ -283,6 +383,16 @@ static SnukTokenType check_values(const char *s, uint64_t len) {
     return SNUK_TOKEN_EOF;
 }
 
+/**
+ * @brief Scan a line or block comment body.
+ *
+ * @param lexer Lexer state positioned after the comment opener.
+ * @param multi_line True for block comments, false for line comments.
+ *
+ * @return Comment or error token.
+ *
+ * @note The caller must have already consumed both opener characters.
+ */
 static SnukToken lexer_scan_comment(SnukLexer *lexer, bool multi_line) {
     lexer->token_start = lexer->cur;
     lexer->token_start_line = lexer->line;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -6,6 +6,12 @@
 
 SNUK_STATIC_ASSERT(sizeof(double) == 8, "Expected sizeof(double) to be 8 bytes.");
 
+/**
+ * @brief Token categories emitted by the Snuk lexer.
+ *
+ * Includes literal values, keywords, punctuation, operators, comments, errors,
+ * and end-of-file markers.
+ */
 typedef enum SnukTokenType {
     SNUK_TOKEN_EOF = 0,
     SNUK_TOKEN_ERROR,
@@ -109,6 +115,16 @@ typedef enum SnukTokenType {
     SNUK_TOKEN_MAX
 } SnukTokenType;
 
+/**
+ * @brief Lexical token produced from Snuk source text.
+ *
+ * The token type selects which union member is meaningful: string_literal for
+ * textual tokens and error context, int_literal for integer literals, and
+ * float_literal for floating-point literals. The line and column fields record
+ * the token start using zero-based source coordinates.
+ *
+ * @note String views point into the source buffer owned by the caller.
+ */
 typedef struct SnukToken {
     SnukTokenType type;
     union {
@@ -122,6 +138,14 @@ typedef struct SnukToken {
     uint64_t line, col;
 } SnukToken;
 
+/**
+ * @brief Mutable scanner state for a null-terminated Snuk source string.
+ *
+ * Tracks the original source, the current cursor, the current token start, and
+ * zero-based line and column positions for both cursor and token start.
+ *
+ * @note The source buffer must remain valid for the lifetime of the lexer.
+ */
 typedef struct SnukLexer {
     const char *src;
 
@@ -134,6 +158,15 @@ typedef struct SnukLexer {
     uint64_t col;
 } SnukLexer;
 
+/**
+ * @brief Initialize a lexer for the given source string.
+ *
+ * @param lexer Lexer state to initialize.
+ * @param src Null-terminated source buffer to scan.
+ *
+ * @note The source buffer is borrowed and must outlive all tokens produced by
+ * the lexer.
+ */
 SNUK_INLINE void snuk_lexer_init(SnukLexer *lexer, const char *src) {
     *lexer = (SnukLexer){
         .src = src,
@@ -146,11 +179,38 @@ SNUK_INLINE void snuk_lexer_init(SnukLexer *lexer, const char *src) {
     };
 }
 
+/**
+ * @brief Reset a lexer to an empty state.
+ *
+ * @param lexer Lexer state to clear, or NULL.
+ */
 SNUK_INLINE void snuk_lexer_deinit(SnukLexer *lexer) {
     if (lexer) *lexer = (SnukLexer){0};
 }
 
+/**
+ * @brief Scan and return the next token from the lexer.
+ *
+ * Advances the lexer past leading whitespace and the returned token.
+ *
+ * @param lexer Lexer state to scan from.
+ *
+ * @return The next token, including comments, errors, or end-of-file.
+ */
 SnukToken snuk_lexer_next_token(SnukLexer *lexer);
 
+/**
+ * @brief Convert a token type to a readable string.
+ *
+ * @param type Token type to convert.
+ *
+ * @return String literal naming the token type.
+ */
 const char *snuk_lexer_token_type_to_string(SnukTokenType type);
+
+/**
+ * @brief Log a token for debugging.
+ *
+ * @param token Token to log.
+ */
 void snuk_lexer_log_token(SnukToken token);


### PR DESCRIPTION
Adds Doxygen documentation comments to the lexer's public API (`src/lexer.h`) and internal static helpers (`src/lexer.c`), matching the `/**\n * @brief ...\n */` style already used in `src/darray.h`.

## Summary

- Closes #30
- +170 lines, **0 code deletions** (comments only)
- Anchored on `src/darray.h`'s existing style (since `external/SnLogger` / `external/SnMemory` / `external/SnFile` submodules are empty in a fresh clone)

## Coverage

### `src/lexer.h`
- `SnukTokenType`: one `@brief` block above the enum. Existing inline `// (`, `// )` etc. comments on individual constants are preserved.
- `SnukToken` struct: `@brief` + `@note` on the string_view-into-source ownership rule.
- `SnukLexer` struct: `@brief` + `@note` on the source-buffer lifetime requirement.
- Public inline `snuk_lexer_init`, `snuk_lexer_deinit`: full `@brief` / `@param` / `@note`.
- Forward-declared `snuk_lexer_next_token`, `snuk_lexer_token_type_to_string`, `snuk_lexer_log_token`: `@brief` / `@param` / `@return` as appropriate.

### `src/lexer.c`
- Every `static` / `SNUK_INLINE` helper has at minimum a `@brief` line (e.g., `lexer_is_eof`, `lexer_peek`, `lexer_peek_next`, `lexer_advance`, scanners for string/number/identifier, the keyword/value matchers, comment scanners, error producers, etc.).
- `@param` lines added where the argument list isn't self-explanatory.
- `@note` invariants added where the helper assumes the caller has done something (e.g., "caller must have already consumed the leading `/`").

## Non-changes

- No behavior changes anywhere. `git diff | grep '^-[^-]'` returns zero lines.
- No build config, no tests, no other files touched.
- Existing `//` trailing comments on enum constants were left alone per the issue's direction ("Every public function, struct, enum, etc., in the header has a Doxygen doc comment" — interpreted as the enum-as-a-whole, not per-constant).

## Testing

- `git diff --check`: clean (no whitespace errors).
- CMake configure: blocked at submodule init (`external/SnLogger`, `external/SnMemory`, `external/SnFile` are empty in this clone). Comments are inert w.r.t. compilation, so the doxygen additions cannot affect the build outcome.
- Compared style side-by-side against `src/darray.h` — same block structure, same ordering of `@brief` → description → `@param` → `@return` → `@note`.

---

This contribution was developed with AI assistance (Codex).
