### PR TITLE
feat: add snuk_string_view_equal function in string_view.h which comp…

### DIFF
--- a/src/string_view.h
+++ b/src/string_view.h
@@ -48,3 +48,10 @@ SNUK_INLINE SnukStringView snuk_string_view_concat(SnukStringView a, SnukStringV
         .len = a.len + b.len,
     };
 }
+
+SNUK_INLINE bool snuk_string_view_equal(SnukStringView a, SnukStringView b) {
+    if (a.len != b.len) return false;
+    if (a.len == 0)  return true;
+    
+    return memcmp(a.str, b.str, a.len) == 0;
+}

--- a/tests/unit/string_view.c
+++ b/tests/unit/string_view.c
@@ -1,0 +1,21 @@
+#include "test_framework.h"
+
+#include <string_view.h>
+
+ADD_TEST(test_string_view_equal) {
+    SnukStringView a = snuk_string_view_create("hello");
+    SnukStringView b = snuk_string_view_create("hello");
+    SnukStringView c = snuk_string_view_create("world");
+    SnukStringView d = snuk_string_view_create("hell");
+    SnukStringView e = snuk_string_view_create("");
+    SnukStringView f = snuk_string_view_create("");
+
+    ASSERT(snuk_string_view_equal(a, b));
+    ASSERT(!snuk_string_view_equal(a, c));
+    ASSERT(!snuk_string_view_equal(a, d));
+    ASSERT(snuk_string_view_equal(e, f));
+
+    TEST_PASSED;
+}
+
+RUN_ALL_TESTS();


### PR DESCRIPTION
Closes #78

## What does this PR do?

Adds `snuk_string_view_equal` to compare two `SnukStringView` values by length and contents.

Also adds unit tests covering equal views, different contents, different lengths, and empty views.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation
- [ ] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [ ] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [x] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

Tested with:

```sh
cmake --build build --target run_tests
