### PR TITLE
test: add unit tests for string_view

### DIFF
--- a/tests/unit/string_view.c
+++ b/tests/unit/string_view.c
@@ -1,0 +1,64 @@
+#include "test_framework.h"
+
+#include <memory.h>
+#include <snuk_string.h>
+#include <string_view.h>
+
+ADD_TEST(test_string_view_create_with_len) {
+    SnukStringView view = snuk_string_view_create_with_len("hello world", 5);
+
+    ASSERT_EQ(view.len, 5);
+    ASSERT(view.str != NULL);
+    ASSERT(snuk_string_n_equal(view.str, "hello", 5));
+
+    TEST_PASSED;
+}
+
+ADD_TEST(test_string_view_create) {
+    SnukStringView view = snuk_string_view_create("hello");
+
+    ASSERT_EQ(view.len, 5);
+    ASSERT(view.str != NULL);
+    ASSERT(snuk_string_equal(view.str, "hello"));
+
+    TEST_PASSED;
+}
+
+ADD_TEST(test_string_view_get_cstr) {
+    SnukStringView view = snuk_string_view_create("hello world");
+    char* str = snuk_string_view_get_cstr(view);
+
+    ASSERT(snuk_string_equal(str, "hello world"));
+
+    snuk_free(str);
+
+    TEST_PASSED;
+}
+
+ADD_TEST(test_string_view_copy) {
+    SnukStringView view = snuk_string_view_create("hello world");
+    SnukStringView copy = snuk_string_view_copy(view);
+
+    ASSERT_EQ(view.len, copy.len);
+    ASSERT(copy.str != view.str);
+    ASSERT(snuk_string_equal(view.str, copy.str));
+
+    snuk_free((void *)copy.str);
+
+    TEST_PASSED;
+}
+
+ADD_TEST(test_string_view_concat) {
+    SnukStringView a = snuk_string_view_create("hello");
+    SnukStringView b = snuk_string_view_create(" world");
+    SnukStringView result = snuk_string_view_concat(a, b);
+
+    ASSERT_EQ(result.len, 11);
+    ASSERT(snuk_string_n_equal(result.str, "hello world", result.len));
+
+    snuk_free((void *)result.str);
+
+    TEST_PASSED;
+}
+
+RUN_ALL_TESTS();


### PR DESCRIPTION
Closes #73

## What does this PR do?

Adds unit tests for the existing `string_view.h` helpers.

Covered functions:

- `snuk_string_view_create_with_len`
- `snuk_string_view_create`
- `snuk_string_view_get_cstr`
- `snuk_string_view_copy`
- `snuk_string_view_concat`

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation
- [ ] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [x] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [x] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

Tested with:

```sh
cmake --build build --target run_tests
