### PR TITLE
docs: add operator overloading idea

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -40,7 +40,7 @@ Nothing here is guaranteed — this is a thinking space, not a roadmap.
 - Package manager integration
 
 
-# Language additions ?
+# Language additions
 
 ## Interfaces
 
@@ -78,3 +78,17 @@ fn string.shout() {
 }
 ```
 - Language syntax grows
+
+## Operator overloading
+
+Allow operator overloading.
+
+```snuk
+type Point {
+    var x: int
+    var y: int
+    fn +(other_obj) {
+        Point {x: self.x + other_obj.x, y: self.y + other_obj.y}
+    }
+}
+```


### PR DESCRIPTION
## What does this PR do?

<!-- one or two sentences -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation
- [ ] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [ ] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [ ] Builds without warnings (`-Wall -Wextra`)
- [ ] Existing test files still pass
- [ ] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

<!-- optional — edge cases, open questions, related issues -->
