### PR TITLE
test: add new assertion macros to test framework

### DIFF
--- a/tests/unit/test_framework.h
+++ b/tests/unit/test_framework.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 #include <logger.h>
+#include <string.h>
 #include <memory.h>
 
 typedef bool (*snuk_test_fn)(void);
@@ -179,7 +180,12 @@ static inline bool snuk_run_all_tests(void) {
         const char *snuk_str_a = (a); \
         const char *snuk_str_b = (b); \
         \
-        if (!snuk_string_equal(snuk_str_a, snuk_str_b)) { \
+        bool snuk_equal = \
+            (snuk_str_a == NULL && snuk_str_b == NULL) || \
+            (snuk_str_a != NULL && snuk_str_b != NULL && \
+             strcmp(snuk_str_a, snuk_str_b) == 0); \
+        \
+        if (!snuk_equal) { \
             log_error( \
                 "Assertion failed: strings %s == %s (%s:%d) in %s\n" \
                 "  left : \"%s\"\n" \
@@ -197,7 +203,12 @@ static inline bool snuk_run_all_tests(void) {
         const char *snuk_str_a = (a); \
         const char *snuk_str_b = (b); \
         \
-        if (snuk_string_equal(snuk_str_a, snuk_str_b)) { \
+        bool snuk_equal = \
+            (snuk_str_a == NULL && snuk_str_b == NULL) || \
+            (snuk_str_a != NULL && snuk_str_b != NULL && \
+             strcmp(snuk_str_a, snuk_str_b) == 0); \
+        \
+        if (snuk_equal) { \
             log_error( \
                 "Assertion failed: strings %s != %s (%s:%d) in %s\n" \
                 "  both: \"%s\"", \
@@ -214,7 +225,12 @@ static inline bool snuk_run_all_tests(void) {
         const char *snuk_str_b = (b); \
         size_t snuk_str_n = (n); \
         \
-        if (!snuk_string_n_equal(snuk_str_a, snuk_str_b, snuk_str_n)) { \
+        bool snuk_equal = \
+            (snuk_str_a == NULL && snuk_str_b == NULL) || \
+            (snuk_str_a != NULL && snuk_str_b != NULL && \
+             strncmp(snuk_str_a, snuk_str_b, snuk_str_n) == 0); \
+        \
+        if (!snuk_equal) { \
             log_error( \
                 "Assertion failed: first %zu chars of %s == %s (%s:%d) in %s", \
                 snuk_str_n, #a, #b, __FILE__, __LINE__, __func__ \

--- a/tests/unit/test_framework.h
+++ b/tests/unit/test_framework.h
@@ -123,7 +123,135 @@ static inline bool snuk_run_all_tests(void) {
 #define ASSERT_EQ(a, b) \
     do { \
         if ((a) != (b)) { \
-            log_error("Assertion failed: %s == %s (%s:%d) in %s", #a, #b, __FILE__, __LINE__, __func__); \
+            log_error("Assertion failed: %s == %s (%s:%d) in %s", \
+            #a, #b, __FILE__, __LINE__, __func__); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_NE(a, b) \
+    do { \
+        if ((a) == (b)) { \
+            log_error("Assertion failed: %s != %s (%s:%d) in %s", \
+            #a, #b, __FILE__, __LINE__, __func__); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_NULL(x) \
+    do { \
+        if ((x) != NULL) { \
+            log_error("Assertion failed: expected %s to be NULL (%s:%d) in %s", \
+            #x, __FILE__, __LINE__, __func__); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_NOT_NULL(x) \
+    do { \
+        if ((x) == NULL) { \
+            log_error("Assertion failed: expected %s to be non-NULL (%s:%d) in %s", \
+            #x, __FILE__, __LINE__, __func__); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_PTR_EQ(a, b) \
+    do { \
+        if ((void *)(a) != (void *)(b)) { \
+            log_error("Assertion failed: pointers %s == %s (%s:%d) in %s", \
+            #a, #b, __FILE__, __LINE__, __func__); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_PTR_NE(a, b) \
+    do { \
+        if ((void *)(a) == (void *)(b)) { \
+            log_error("Assertion failed: pointers %s != %s (%s:%d) in %s", \
+            #a, #b, __FILE__, __LINE__, __func__); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_STR_EQ(a, b) \
+    do { \
+        const char *snuk_str_a = (a); \
+        const char *snuk_str_b = (b); \
+        \
+        if (!snuk_string_equal(snuk_str_a, snuk_str_b)) { \
+            log_error( \
+                "Assertion failed: strings %s == %s (%s:%d) in %s\n" \
+                "  left : \"%s\"\n" \
+                "  right: \"%s\"", \
+                #a, #b, __FILE__, __LINE__, __func__, \
+                snuk_str_a ? snuk_str_a : "(null)", \
+                snuk_str_b ? snuk_str_b : "(null)" \
+            ); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_STR_NE(a, b) \
+    do { \
+        const char *snuk_str_a = (a); \
+        const char *snuk_str_b = (b); \
+        \
+        if (snuk_string_equal(snuk_str_a, snuk_str_b)) { \
+            log_error( \
+                "Assertion failed: strings %s != %s (%s:%d) in %s\n" \
+                "  both: \"%s\"", \
+                #a, #b, __FILE__, __LINE__, __func__, \
+                snuk_str_a ? snuk_str_a : "(null)" \
+            ); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_STR_N_EQ(a, b, n) \
+    do { \
+        const char *snuk_str_a = (a); \
+        const char *snuk_str_b = (b); \
+        size_t snuk_str_n = (n); \
+        \
+        if (!snuk_string_n_equal(snuk_str_a, snuk_str_b, snuk_str_n)) { \
+            log_error( \
+                "Assertion failed: first %zu chars of %s == %s (%s:%d) in %s", \
+                snuk_str_n, #a, #b, __FILE__, __LINE__, __func__ \
+            ); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_CHAR_EQ(a, b) \
+    do { \
+        char snuk_char_a = (a); \
+        char snuk_char_b = (b); \
+        \
+        if (snuk_char_a != snuk_char_b) { \
+            log_error( \
+                "Assertion failed: chars %s == %s (%s:%d) in %s\n" \
+                "  left : '%c' (%d)\n" \
+                "  right: '%c' (%d)", \
+                #a, #b, __FILE__, __LINE__, __func__, \
+                snuk_char_a, snuk_char_a, \
+                snuk_char_b, snuk_char_b \
+            ); \
+            TEST_FAILED; \
+        } \
+    } while (0)
+
+#define ASSERT_MEM_EQ(a, b, size) \
+    do { \
+        const void *snuk_mem_a = (a); \
+        const void *snuk_mem_b = (b); \
+        size_t snuk_mem_size = (size); \
+        \
+        if (memcmp(snuk_mem_a, snuk_mem_b, snuk_mem_size) != 0) { \
+            log_error( \
+                "Assertion failed: memory %s == %s with size %zu (%s:%d) in %s", \
+                #a, #b, snuk_mem_size, __FILE__, __LINE__, __func__ \
+            ); \
             TEST_FAILED; \
         } \
     } while (0)


### PR DESCRIPTION
Closes #74 

## What does this PR do?

Add new assertion macros to the test framework to improve readability, expressiveness, and debugging diagnostics in tests.

The PR also refactors existing tests to use the new assertion helpers where appropriate while keeping the framework minimal and consistent with its current style.

## Type of change

* [ ] `feat` — new feature
* [ ] `fix` — bug fix
* [ ] `docs` — documentation
* [ ] `refactor` — no behavior change
* [ ] `chore` — build / tooling
* [ ] `perf` — performance
* [x] `test` — tests only

## Checklist

* [x] Branch cut from `dev`
* [x] Builds without warnings (`-Wall -Wextra`)
* [x] Existing test files still pass
* [x] New behavior covered by a test file in `tests/`
* [x] Commits follow conventional commit format

## Anything reviewers should know?

Please review the added macros carefully to ensure they are actually justified and consistent with the framework's minimal design philosophy.

I also would appreciate feedback regarding:

* whether some assertions should be removed or simplified,
* whether the macro naming is appropriate,
* whether the added API surface is reasonable,
* and whether the formatting/style matches the project's conventions well.

Feel free to modify or simplify anything you consider unnecessary or inconsistent during review.