### PR TITLE
refactor(test): replace generic assertions with typed macros

### DIFF
--- a/tests/unit/snuk_string.c
+++ b/tests/unit/snuk_string.c
@@ -118,9 +118,9 @@ ADD_TEST(test_string_length) {
 }
 
 ADD_TEST(test_string_equal) {
-    ASSERT(snuk_string_equal("Hi", "Hi"));
-    ASSERT(snuk_string_equal("", ""));
-    ASSERT(!snuk_string_equal("Hello", "Hi"));
+    ASSERT_STR_EQ("Hi", "Hi");
+    ASSERT_STR_EQ("", "");
+    ASSERT_STR_NE("Hello", "Hi");
 
     TEST_PASSED;
 }
@@ -215,19 +215,23 @@ ADD_TEST(test_string_concat) {
     const char *b = "World!";
 
     char *c = snuk_string_concat(a, 0, b, 0);
-    ASSERT(snuk_string_equal(c, "Hello, World!"));
+    ASSERT_NOT_NULL(c);
+    ASSERT_STR_EQ(c, "Hello, World!");
     snuk_free(c);
 
     c = snuk_string_concat(a, 3, b, 2);
-    ASSERT(snuk_string_equal(c, "HelWo"));
+    ASSERT_NOT_NULL(c);
+    ASSERT_STR_EQ(c, "HelWo");
     snuk_free(c);
 
     c = snuk_string_concat(a, 6, b, 6);
-    ASSERT(snuk_string_equal(c, "Hello,World!"));
+    ASSERT_NOT_NULL(c);
+    ASSERT_STR_EQ(c, "Hello,World!");
     snuk_free(c);
 
     c = snuk_string_concat(a, 7, b, 6);
-    ASSERT(snuk_string_equal(c, "Hello, World!"));
+    ASSERT_NOT_NULL(c);
+    ASSERT_STR_EQ(c, "Hello, World!");
     snuk_free(c);
 
     TEST_PASSED;

--- a/tests/unit/snuk_string.c
+++ b/tests/unit/snuk_string.c
@@ -95,9 +95,9 @@ ADD_TEST(test_is_hex_digit) {
     TEST_PASSED;
 }
 
-ADD_TEST(test_string_length_edge_cases) {
+ADD_TEST(test_string_length) {
     // basic cases
-    ASSERT_EQ(snuk_string_length("hello"), 5);
+    ASSERT_EQ(snuk_string_length("Hello"), 5);
     ASSERT_EQ(snuk_string_length(""), 0);
 
     // string with spaces and symbols
@@ -110,17 +110,10 @@ ADD_TEST(test_string_length_edge_cases) {
     TEST_PASSED;
 }
 
-ADD_TEST(test_string_length) {
-    ASSERT_EQ(snuk_string_length("Hello"), 5);
-    ASSERT_EQ(snuk_string_length(""), 0);
-
-    TEST_PASSED;
-}
-
 ADD_TEST(test_string_equal) {
-    ASSERT_STR_EQ("Hi", "Hi");
-    ASSERT_STR_EQ("", "");
-    ASSERT_STR_NE("Hello", "Hi");
+    ASSERT(snuk_string_equal("Hi", "Hi"));
+    ASSERT(snuk_string_equal("", ""));
+    ASSERT(!snuk_string_equal("Hello", "Hi"));
 
     TEST_PASSED;
 }

--- a/tests/unit/string_view.c
+++ b/tests/unit/string_view.c
@@ -8,8 +8,8 @@ ADD_TEST(test_string_view_create_with_len) {
     SnukStringView view = snuk_string_view_create_with_len("hello world", 5);
 
     ASSERT_EQ(view.len, 5);
-    ASSERT(view.str != NULL);
-    ASSERT(snuk_string_n_equal(view.str, "hello", 5));
+    ASSERT_NOT_NULL(view.str);
+    ASSERT_STR_N_EQ(view.str, "hello", 5);
 
     TEST_PASSED;
 }
@@ -18,17 +18,18 @@ ADD_TEST(test_string_view_create) {
     SnukStringView view = snuk_string_view_create("hello");
 
     ASSERT_EQ(view.len, 5);
-    ASSERT(view.str != NULL);
-    ASSERT(snuk_string_equal(view.str, "hello"));
+    ASSERT_NOT_NULL(view.str);
+    ASSERT_STR_EQ(view.str, "hello");
 
     TEST_PASSED;
 }
 
 ADD_TEST(test_string_view_get_cstr) {
     SnukStringView view = snuk_string_view_create("hello world");
-    char* str = snuk_string_view_get_cstr(view);
+    char *str = snuk_string_view_get_cstr(view);
 
-    ASSERT(snuk_string_equal(str, "hello world"));
+    ASSERT_NOT_NULL(str);
+    ASSERT_STR_EQ(str, "hello world");
 
     snuk_free(str);
 
@@ -40,8 +41,8 @@ ADD_TEST(test_string_view_copy) {
     SnukStringView copy = snuk_string_view_copy(view);
 
     ASSERT_EQ(view.len, copy.len);
-    ASSERT(copy.str != view.str);
-    ASSERT(snuk_string_equal(view.str, copy.str));
+    ASSERT_PTR_NE(copy.str, view.str);
+    ASSERT_STR_EQ(view.str, copy.str);
 
     snuk_free((void *)copy.str);
 
@@ -54,10 +55,11 @@ ADD_TEST(test_string_view_concat) {
     SnukStringView result = snuk_string_view_concat(a, b);
 
     ASSERT_EQ(result.len, 11);
-    ASSERT(snuk_string_n_equal(result.str, "hello world", result.len));
+    ASSERT_NOT_NULL(result.str);
+    ASSERT_STR_N_EQ(result.str, "hello world", result.len);
 
     snuk_free((void *)result.str);
-  
+
     TEST_PASSED;
 }
 


### PR DESCRIPTION
## What does this PR do?

Refactors string-related unit tests by replacing generic assertions with typed assertion macros and removing duplicated string length tests.

## Type of change

* [ ] `feat` — new feature
* [ ] `fix` — bug fix
* [ ] `docs` — documentation
* [x] `refactor` — no behavior change
* [ ] `chore` — build / tooling
* [ ] `perf` — performance
* [ ] `test` — tests only

## Checklist

* [x] Branch cut from `dev`
* [x] Builds without warnings (`-Wall -Wextra`)
* [x] Existing test files still pass
* [ ] New behavior covered by a test file in `tests/`
* [x] Commits follow conventional commit format

## Anything reviewers should know?

This PR refactors existing tests and does not introduce behavioral changes.
