### PR TITLE
feat(parser): add list literal parsing

### DIFF
--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -260,6 +260,7 @@ SnukValue snuk_interpreter_eval_expr(SnukInterpreter *intpret, SnukExpr *expr) {
         }
 
         case SNUK_EXPR_INDEX:
+        case SNUK_EXPR_LIST:
         case SNUK_EXPR_LINE_COMMENT:
         case SNUK_EXPR_BLOCK_COMMENT:
             return (SnukValue){.type = SNUK_VALUE_NULL};

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -45,7 +45,7 @@ SNUK_INLINE void scope_depth_add_bracket(ScopeDepth *sd) {
 
 SNUK_INLINE void scope_depth_remove_bracket(ScopeDepth *sd) {
     uint64_t last = snuk_darray_get_length(sd) - 1;
-    SNUK_ASSERT(sd[last].paren > 0, "scope mismatch");
+    SNUK_ASSERT(sd[last].bracket > 0, "scope mismatch");
     sd[last].bracket--;
 }
 

--- a/src/parser/snuk_expr.c
+++ b/src/parser/snuk_expr.c
@@ -195,6 +195,15 @@ static SnukExpr *parse_call(SnukParser *parser, SnukExpr *left);
 static SnukExpr *parse_comment(SnukParser *parser);
 
 /**
+ * @brief Parse a list literal.
+ *
+ * @param parser Parser context to work on.
+ *
+ * @return Parsed expression, or NULL on parse failure.
+ */
+static SnukExpr *parse_list(SnukParser *parser);
+
+/**
  * @brief Parse the type token.
  *
  * @param parser Parser context to operate on.
@@ -236,6 +245,7 @@ static ParseRule rules[] = {
     [SNUK_TOKEN_INF]            = {parse_primary,    NULL,                      PRECEDENCE_NONE       },
 
     [SNUK_TOKEN_LPAREN]         = {parse_grouping,   parse_call,                PRECEDENCE_PRIMARY    },
+    [SNUK_TOKEN_LBRACKET]       = {parse_list,       NULL,                      PRECEDENCE_NONE       },
 
     [SNUK_TOKEN_PLUS]           = {parse_unary,      parse_binary,              PRECEDENCE_TERM       },
     [SNUK_TOKEN_MINUS]          = {parse_unary,      parse_binary,              PRECEDENCE_TERM       },
@@ -596,6 +606,23 @@ static SnukExpr *parse_comment(SnukParser *parser) {
     return build_comment_expr(parser, t);
 }
 
+static SnukExpr *parse_list(SnukParser *parser) {
+    SnukExpr **elements = snuk_darray_create(SnukExpr *, parser->allocator);
+    while (!parser_match(parser, SNUK_TOKEN_RBRACKET) && parser->current.type != SNUK_TOKEN_EOF) {
+        SnukExpr *expr = snuk_expr_parse(parser);
+        snuk_darray_push(&elements, expr);
+        if (!parser_check(parser, SNUK_TOKEN_RBRACKET))
+            parser_expect(parser, SNUK_TOKEN_COMMA, "expected ',' or ']' after list element");
+    }
+    
+    if (parser->previous.type != SNUK_TOKEN_RBRACKET) {
+        parser_error(parser, "expected ']' after list elements");
+        return NULL;
+    }
+    
+    return build_list_expr(parser, elements);
+}
+
 static SnukExpr *parse_type(SnukParser *parser, SnukStringView name) {
     parser_expect(parser, SNUK_TOKEN_LBRACE, "expected '{'");
 
@@ -742,6 +769,8 @@ const char *snuk_expr_type_to_string(SnukExprType type) {
             return SNUK_STRINGIFY(SNUK_EXPR_MEMBER);
         case SNUK_EXPR_INDEX:
             return SNUK_STRINGIFY(SNUK_EXPR_INDEX);
+        case SNUK_EXPR_LIST:
+            return SNUK_STRINGIFY(SNUK_EXPR_LIST);
         case SNUK_EXPR_LINE_COMMENT:
             return SNUK_STRINGIFY(SNUK_EXPR_LINE_COMMENT);
         case SNUK_EXPR_BLOCK_COMMENT:
@@ -867,6 +896,14 @@ void snuk_expr_log(SnukExpr *expr) {
             // TODO:
             log_trace("Index:", NULL);
             break;
+        case SNUK_EXPR_LIST: {
+            log_trace("List:", NULL);
+            uint64_t len = snuk_darray_get_length(expr->list.elements);
+            for (uint64_t i = 0; i < len; ++i) {
+                snuk_expr_log(expr->list.elements[i]);
+            }
+            break;
+        }
         case SNUK_EXPR_LINE_COMMENT:
             log_trace("single line comment: " SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(expr->comment));
             break;

--- a/src/parser/snuk_expr.c
+++ b/src/parser/snuk_expr.c
@@ -614,12 +614,12 @@ static SnukExpr *parse_list(SnukParser *parser) {
         if (!parser_check(parser, SNUK_TOKEN_RBRACKET))
             parser_expect(parser, SNUK_TOKEN_COMMA, "expected ',' or ']' after list element");
     }
-    
+
     if (parser->previous.type != SNUK_TOKEN_RBRACKET) {
         parser_error(parser, "expected ']' after list elements");
         return NULL;
     }
-    
+
     return build_list_expr(parser, elements);
 }
 

--- a/src/parser/snuk_expr.h
+++ b/src/parser/snuk_expr.h
@@ -39,6 +39,7 @@ typedef enum SnukExprType {
     SNUK_EXPR_MEMBER, /**< Member access expression. */
     SNUK_EXPR_SELF, /**< Self expression. */
     SNUK_EXPR_INDEX, /**< Index access expression. */
+    SNUK_EXPR_LIST, /**< List literal expression. */
 
     SNUK_EXPR_LINE_COMMENT, /**< Single line comment */
     SNUK_EXPR_BLOCK_COMMENT, /**< Multi line comment */
@@ -142,6 +143,10 @@ struct SnukExpr {
                                field/member */
             SnukExpr *field; /**< The field/member */
         } member_access;
+
+        struct {
+            SnukExpr **elements; /**< Darray of list elements */
+        } list;
     };
 };
 
@@ -549,6 +554,23 @@ SNUK_INLINE SnukExpr *build_member_access_expr(SnukParser *parser, SnukExpr *typ
 SNUK_INLINE SnukExpr *build_self_expr(SnukParser *parser) {
     SnukExpr *expr = parser_create_expr(parser);
     *expr = (SnukExpr){.type = SNUK_EXPR_SELF};
+    return expr;
+}
+
+/**
+ * @brief Build list expression node.
+ *
+ * @param parser Parser context to operate on.
+ * @param elements Dynamic array of list elements.
+ *
+ * @return Newly allocated list expression node.
+ */
+SNUK_INLINE SnukExpr *build_list_expr(SnukParser *parser, SnukExpr **elements) {
+    SnukExpr *expr = parser_create_expr(parser);
+    *expr = (SnukExpr){
+        .type = SNUK_EXPR_LIST,
+        .list = {.elements = elements},
+    };
     return expr;
 }
 

--- a/tests/list_literal.snuk
+++ b/tests/list_literal.snuk
@@ -1,0 +1,48 @@
+// Basic list literals
+var empty = []
+var numbers = [1, 2, 3, 4, 5]
+var mixed = [1, "hello", true, null]
+var nested = [[1, 2], [3, 4]]
+
+// Trailing commas
+var trailing = [1, 2, ]
+var single_trailing = [42,]
+
+// Single element
+var single = [42]
+
+// Expressions and operations
+var ops = [1 + 2, 3 * 4, 10 / 2, 5 % 2]
+var bool_ops = [true && false, !true, 1 == 1, 5 > 3]
+
+// Function calls inside list
+fn get_num() -> any { return 99 }
+var with_calls = [get_num(), get_num() + 1]
+
+// Multi-line list literals
+var multiline = [
+    1,
+    2,
+    3,
+]
+
+// Function expressions inside list
+var fn_list = [
+    fn() { print "first" },
+    fn() { print "second" }
+]
+
+// Types and type instances inside list
+var type_list = [
+    type { var x = 1 },
+    type { var y = "test" }
+]
+
+// Empty nested lists
+var empty_nested = [[], [[]], [[], []]]
+
+// Deeply nested list
+var deep = [1, [2, [3, [4, "end"]]], 5]
+
+// Print some results to verify parser didn't crash
+print "Successfully parsed 15 list variants!"


### PR DESCRIPTION
## What does this PR do?

This PR introduces parsing support for array-style list literals in Snuk, generating AST nodes for scenarios ranging from empty lists ([]) to nested, multi-line, and mixed-type lists. It adds SNUK_EXPR_LIST to the parser's expression enum using a dynamic array of expressions and implements native support for trailing commas.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation
- [ ] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [ ] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [x] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

- Interpreter Fallback: The execution of SNUK_EXPR_LIST in interpreter.c simply falls back to returning SNUK_VALUE_NULL to bypass -Wswitch compilation warnings. The actual runtime memory representation and execution bindings for Snuk lists are left open for a future PR.
- Trailing Commas: The list parsing structure closely mirrors how function call arguments (parse_call) are handled, giving us robust, out-of-the-box support for optional trailing commas (e.g. [1, 2,]).
- Tests: Added tests/list_literal.snuk featuring 15 comprehensive edge cases proving stability.
