### PR TITLE
fix: set up strong and weak ref counters to scopes

### DIFF
--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -6,6 +6,25 @@
 
 #include <stdio.h>
 
+typedef struct PredefinedTypes {
+    const char *type;
+    SnukValueType val_type;
+} PredefinedTypes;
+
+static PredefinedTypes pre_def_types[] = {
+    {.type = "int",   .val_type = SNUK_VALUE_INT   },
+    {.type = "float", .val_type = SNUK_VALUE_FLOAT },
+    {.type = "bool",  .val_type = SNUK_VALUE_BOOL  },
+    {.type = "str",   .val_type = SNUK_VALUE_STRING},
+};
+
+SNUK_INLINE SnukValueType get_predef_type(SnukStringView name) {
+    for (uint64_t i = 0; i < SNUK_ARRAY_LENGTH(pre_def_types); ++i)
+        if (snuk_string_view_equal_cstr(name, pre_def_types[i].type))
+            return pre_def_types[i].val_type;
+    return SNUK_VALUE_UNKOWN;
+}
+
 /**
  * @brief Walk the scope chain from current to global to resolve a name.
  */
@@ -17,7 +36,7 @@ SNUK_INLINE SnukEnv *interpreter_lookup(SnukInterpreter *intpret, SnukStringView
  * @brief Push a new child scope and make it the interpreter's current scope.
  */
 SNUK_INLINE void interpreter_push_scope(SnukInterpreter *intpret) {
-    intpret->current = snuk_scope_create(snuk_ref_counter_move(&intpret->current));
+    intpret->current = snuk_scope_create(snuk_ref_counter_move(&intpret->current), false);
 }
 
 /**
@@ -34,27 +53,30 @@ SNUK_INLINE void interpreter_pop_scope(SnukInterpreter *intpret) {
     intpret->current = snuk_ref_counter_move(&parent);
 }
 
-static void execute_print_expr(SnukInterpreter *intpret, SnukExpr **exprs);
+static void execute_print_item(SnukInterpreter *intpret, SnukExpr **exprs, bool weak_ref);
 static SnukValue execute_block_expr(
-    SnukInterpreter *intpret, SnukExpr *block, int capture_signals, int propogate_signals);
-static SnukValue execute_if_expr(SnukInterpreter *intpret, SnukExpr *expr);
-static SnukValue execute_while_expr(SnukInterpreter *intpret, SnukExpr *loop);
-static SnukValue execute_for_expr(SnukInterpreter *intpret, SnukExpr *loop);
-static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *expr);
-static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr);
-static SnukValue execute_fn_expr(SnukInterpreter *intpret, SnukExpr *expr);
-static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukValue fn, SnukExpr **params);
-static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_or_inst, SnukExpr *field);
-static SnukValue
-    execute_binary_op(SnukInterpreter *intpret, SnukValue left, SnukExpr *right_expr, SnukTokenType op);
+    SnukInterpreter *intpret, SnukExpr *block, int capture_signals, int propogate_signals, bool weak_ref);
+static SnukValue execute_if_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref);
+static SnukValue execute_while_expr(SnukInterpreter *intpret, SnukExpr *loop, bool weak_ref);
+static SnukValue execute_for_expr(SnukInterpreter *intpret, SnukExpr *loop, bool weak_ref);
+static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref);
+static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukValue type, SnukExpr *expr, bool weak_ref);
+static SnukValue execute_fn_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref);
+static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukValue fn, SnukExpr **params, bool weak_ref);
+static SnukValue execute_member_access(
+    SnukInterpreter *intpret, SnukValue type_or_inst, SnukExpr *field, bool weak_ref);
+static SnukValue execute_binary_op(
+    SnukInterpreter *intpret, SnukValue left, SnukExpr *right_expr, SnukTokenType op, bool weak_ref);
 static SnukValue perform_binary_op(SnukValue left, SnukValue right, SnukTokenType op);
-static SnukValue
-    get_binary_op_value(SnukInterpreter *intpret, SnukValue lhs, SnukExpr *rhs_expr, SnukTokenType op);
+static SnukValue get_binary_op_value(
+    SnukInterpreter *intpret, SnukValue lhs, SnukExpr *rhs_expr, SnukTokenType op, bool weak_ref);
 static SnukValue execute_unary_op(SnukValue val, SnukTokenType op);
+static SnukValue interpreter_exec_item(SnukInterpreter *intpret, SnukItem *item, bool weak_ref);
+static SnukValue interpreter_eval_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref);
 
 void snuk_interpreter_init(SnukInterpreter *intpret) {
     *intpret = (SnukInterpreter){
-        .global = snuk_scope_create(NULL),
+        .global = snuk_scope_create(NULL, false),
         .signal = SNUK_SIGNAL_NONE,
     };
     intpret->current = snuk_ref_counter_retain(intpret->global);
@@ -63,17 +85,38 @@ void snuk_interpreter_init(SnukInterpreter *intpret) {
 void snuk_interpreter_deinit(SnukInterpreter *intpret) {
     if (!intpret) return;
 
-    SnukRefCounter *rc = intpret->current;
-    while (rc) {
-        SnukScope *scope = GET_SCOPE(rc);
-        snuk_scope_destroy_envs(scope);
-        rc = scope->parent;
-    }
-
     snuk_ref_counter_release(&intpret->current);
     snuk_ref_counter_release(&intpret->global);
 
     *intpret = (SnukInterpreter){0};
+}
+
+bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value, SnukType *type) {
+    // in case of parameter without default value, value will be unknown
+    if (value.type == SNUK_VALUE_UNKOWN) return true;
+
+    if (value.type == SNUK_VALUE_NULL || type->type == TYPE_ANY) return true;
+
+    if (type->type == TYPE_FN && value.type == SNUK_VALUE_FN)
+        return snuk_type_equal(value.fn_value.type, type);
+
+    if (type->type == TYPE_TYPE && (value.type == SNUK_VALUE_TYPE || value.type == SNUK_VALUE_TYPE_INST))
+        return snuk_type_equal(value.type_value.type, type);
+
+    if (type->type == TYPE_NAMED) {
+        if (value.type == get_predef_type(type->name)) return true;
+
+        if (value.type == SNUK_VALUE_TYPE_INST) return snuk_type_equal(value.type_value.type, type);
+
+        if (value.type != SNUK_VALUE_TYPE) return false;
+
+        SnukEnv *env = interpreter_lookup(intpret, type->name);
+        if (!env) return false;
+
+        return snuk_type_equal(value.type_value.type, env->type);
+    }
+
+    return false;
 }
 
 SnukValue snuk_interpreter_get_env(SnukInterpreter *intpret, SnukStringView name) {
@@ -86,8 +129,7 @@ bool snuk_interpreter_set_env(SnukInterpreter *intpret, SnukStringView name, Snu
     SnukEnv *env = interpreter_lookup(intpret, name);
     if (!env) return false;
     if (!snuk_interpreter_value_is_of_type(intpret, value, env->type)) return false;
-    snuk_value_free(env->value);
-    env->value = snuk_value_copy(value);
+    snuk_env_assign_value(env, value);
     return true;
 }
 
@@ -102,176 +144,11 @@ bool snuk_interpreter_create_env(
 }
 
 SnukValue snuk_interpreter_exec_item(SnukInterpreter *intpret, SnukItem *item) {
-    switch (item->type) {
-        case SNUK_ITEM_EXPR:
-            return snuk_interpreter_eval_expr(intpret, item->expr);
-
-        case SNUK_ITEM_VAR_DECL:
-        case SNUK_ITEM_CONST_DECL: {
-            SnukValue value = snuk_interpreter_eval_expr(intpret, item->var->value);
-            SNUK_ASSERT(snuk_interpreter_create_env(intpret, item->var->name, item->var->type,
-                                                    value, item->type == SNUK_ITEM_CONST_DECL),
-                        "duplicate variable");
-            return value;
-        }
-
-        case SNUK_ITEM_PRINT:
-            execute_print_expr(intpret, item->print_exprs);
-            // TODO: return something else?
-            return (SnukValue){.type = SNUK_VALUE_NULL};
-            break;
-
-        // TODO:
-        case SNUK_ITEM_RETURN:
-        case SNUK_ITEM_BREAK: {
-            SnukValue value = {.type = SNUK_VALUE_NULL};
-            if (item->expr) value = snuk_interpreter_eval_expr(intpret, item->expr);
-            intpret->signal = item->type == SNUK_ITEM_RETURN ? SNUK_SIGNAL_RETURN : SNUK_SIGNAL_BREAK;
-            return value;
-        }
-        case SNUK_ITEM_CONTINUE:
-            intpret->signal = SNUK_SIGNAL_CONTINUE;
-            return (SnukValue){.type = SNUK_VALUE_NULL};
-
-        case SNUK_ITEM_MAX:
-        default:
-            break;
-    }
-
-    SNUK_SHOULD_NOT_REACH_HERE;
-    return (SnukValue){.type = SNUK_VALUE_UNKOWN};
+    return interpreter_exec_item(intpret, item, true);
 }
 
-/**
- * @brief Evaluate an expression and return its runtime value.
- */
 SnukValue snuk_interpreter_eval_expr(SnukInterpreter *intpret, SnukExpr *expr) {
-    switch (expr->type) {
-        case SNUK_EXPR_IDENTIFIER:
-            return snuk_interpreter_get_env(intpret, expr->identifier);
-
-        case SNUK_EXPR_INT:
-            return (SnukValue){
-                .type = SNUK_VALUE_INT,
-                .int_value = expr->int_literal,
-            };
-
-        case SNUK_EXPR_FLOAT:
-            return (SnukValue){
-                .type = SNUK_VALUE_FLOAT,
-                .float_value = expr->float_literal,
-            };
-
-        case SNUK_EXPR_STRING:
-            return (SnukValue){
-                .type = SNUK_VALUE_STRING,
-                .string_value = expr->string_literal,
-            };
-
-        case SNUK_EXPR_BOOL:
-            return (SnukValue){
-                .type = SNUK_VALUE_BOOL,
-                .bool_value = expr->bool_literal,
-            };
-
-        case SNUK_EXPR_NULL:
-            return (SnukValue){
-                .type = SNUK_VALUE_NULL,
-            };
-
-        case SNUK_EXPR_UNARY: {
-            SnukValue val = snuk_interpreter_eval_expr(intpret, expr->unary.operand);
-            SnukValue ret = execute_unary_op(val, expr->unary.op);
-            snuk_value_free(val);
-            return ret;
-        }
-
-        case SNUK_EXPR_BINARY: {
-            SnukValue left = snuk_interpreter_eval_expr(intpret, expr->binary.left);
-            SnukValue res = execute_binary_op(intpret, left, expr->binary.right, expr->binary.op);
-            snuk_value_free(left);
-
-            return res;
-        }
-
-        case SNUK_EXPR_ASSIGN: {
-            SnukValue value = snuk_interpreter_eval_expr(intpret, expr->assign.value);
-            SNUK_ASSERT(snuk_interpreter_set_env(intpret, expr->assign.identifier->identifier, value),
-                        "failed to set value");
-            return value;
-        }
-
-        case SNUK_EXPR_COMPOUND_ASSIGN: {
-            SnukValue lhs = snuk_interpreter_eval_expr(intpret, expr->compound_assign.identifier);
-            SnukValue res = get_binary_op_value(
-                intpret, lhs, expr->compound_assign.value, expr->compound_assign.op);
-            snuk_value_free(lhs);
-            SNUK_ASSERT(snuk_interpreter_set_env(intpret, expr->compound_assign.identifier->identifier, res),
-                        "failed to set value");
-            return res;
-        }
-
-        case SNUK_EXPR_IF:
-            return execute_if_expr(intpret, expr);
-
-        // TODO: match
-        case SNUK_EXPR_MATCH:
-            break;
-
-        case SNUK_EXPR_WHILE:
-        case SNUK_EXPR_DO_WHILE:
-            return execute_while_expr(intpret, expr);
-
-        case SNUK_EXPR_FOR:
-            return execute_for_expr(intpret, expr);
-
-        case SNUK_EXPR_FN:
-            return execute_fn_expr(intpret, expr);
-
-        case SNUK_EXPR_TYPE:
-            return execute_type_declaration(intpret, expr);
-
-        case SNUK_EXPR_TYPE_INST:
-            return execute_inst_creation(intpret, expr);
-
-        case SNUK_EXPR_BLOCK:
-            return execute_block_expr(intpret, expr, SNUK_SIGNAL_BREAK, SNUK_SIGNAL_NONE);
-
-        // TODO:
-        case SNUK_EXPR_CALL: {
-            SnukValue fn = snuk_interpreter_eval_expr(intpret, expr->call.fn);
-            SnukValue ret = execute_call_expr(intpret, fn, expr->call.params);
-            snuk_value_free(fn);
-            return ret;
-        }
-
-        case SNUK_EXPR_MEMBER: {
-            SnukValue type_or_inst = snuk_interpreter_eval_expr(intpret, expr->member_access.type);
-            SnukValue ret = execute_member_access(intpret, type_or_inst, expr->member_access.field);
-            snuk_value_free(type_or_inst);
-            return ret;
-        }
-
-        case SNUK_EXPR_SELF: {
-            SnukStringView self = snuk_string_view_create_with_len("self", 4);
-            SnukValue self_value = snuk_interpreter_get_env(intpret, self);
-            SNUK_ASSERT(self_value.type == SNUK_VALUE_TYPE_INST, "self error");
-            return self_value;
-        }
-
-        case SNUK_EXPR_INDEX:
-        case SNUK_EXPR_LIST:
-        case SNUK_EXPR_LINE_COMMENT:
-        case SNUK_EXPR_BLOCK_COMMENT:
-            return (SnukValue){.type = SNUK_VALUE_NULL};
-
-        case SNUK_EXPR_MAX:
-        default:
-            break;
-    }
-
-    SNUK_SHOULD_NOT_REACH_HERE;
-    return (SnukValue){.type = SNUK_VALUE_UNKOWN};
+    return interpreter_eval_expr(intpret, expr, true);
 }
 
 /**
@@ -646,12 +523,12 @@ static void interpreter_print_value(SnukValue value) {
 /**
  * @brief Evaluate each expression in the darray and print its value to stdout.
  */
-static void execute_print_expr(SnukInterpreter *intpret, SnukExpr **exprs) {
+static void execute_print_item(SnukInterpreter *intpret, SnukExpr **exprs, bool weak_ref) {
     if (!exprs) return;
 
     uint64_t count = snuk_darray_get_length(exprs);
     for (uint64_t i = 0; i < count; ++i) {
-        SnukValue value = snuk_interpreter_eval_expr(intpret, exprs[i]);
+        SnukValue value = interpreter_eval_expr(intpret, exprs[i], weak_ref);
         interpreter_print_value(value);
         snuk_print(" ", NULL);
         snuk_value_free(value);
@@ -665,7 +542,7 @@ static void execute_print_expr(SnukInterpreter *intpret, SnukExpr **exprs) {
  * mask and propagating those in the propagate mask.
  */
 static SnukValue execute_block_expr(
-    SnukInterpreter *intpret, SnukExpr *block, int capture_signals, int propogate_signals) {
+    SnukInterpreter *intpret, SnukExpr *block, int capture_signals, int propogate_signals, bool weak_ref) {
     interpreter_push_scope(intpret);
 
     uint64_t count = snuk_darray_get_length(block->block_items);
@@ -673,7 +550,7 @@ static SnukValue execute_block_expr(
 
     for (uint64_t j = 0; j < count; ++j) {
         snuk_value_free(value);
-        value = snuk_interpreter_exec_item(intpret, block->block_items[j]);
+        value = interpreter_exec_item(intpret, block->block_items[j], false);
 
         if (intpret->signal == SNUK_SIGNAL_NONE) continue;
 
@@ -687,24 +564,30 @@ static SnukValue execute_block_expr(
         }
     }
 
+    SnukRefCounter *new_scope = snuk_ref_counter_retain(intpret->current);
     interpreter_pop_scope(intpret);
+
+    if (weak_ref) snuk_scope_downgrade_parent(new_scope);
+
+    snuk_ref_counter_release(&new_scope);
+
     return value;
 }
 
 /**
  * @brief Evaluate an if/else expression by selecting the matching branch block.
  */
-static SnukValue execute_if_expr(SnukInterpreter *intpret, SnukExpr *expr) {
-    SnukValue cond = snuk_interpreter_eval_expr(intpret, expr->if_else.condition);
+static SnukValue execute_if_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref) {
+    SnukValue cond = interpreter_eval_expr(intpret, expr->if_else.condition, weak_ref);
     SnukValue res = {.type = SNUK_VALUE_NULL};
 
     if (snuk_value_is_true(cond)) {
-        res = execute_block_expr(intpret, expr->if_else.then_block, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL);
+        res = execute_block_expr(intpret, expr->if_else.then_block, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL, weak_ref);
     } else if (expr->if_else.else_block) {
         if (expr->if_else.else_block->type == SNUK_EXPR_IF)
-            res = execute_if_expr(intpret, expr->if_else.else_block);
+            res = execute_if_expr(intpret, expr->if_else.else_block, weak_ref);
         else
-            res = execute_block_expr(intpret, expr->if_else.else_block, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL);
+            res = execute_block_expr(intpret, expr->if_else.else_block, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL, weak_ref);
     }
 
     snuk_value_free(cond);
@@ -715,19 +598,19 @@ static SnukValue execute_if_expr(SnukInterpreter *intpret, SnukExpr *expr) {
  * @brief Execute a while or do-while loop, honoring break, continue, and return
  * signals.
  */
-static SnukValue execute_while_expr(SnukInterpreter *intpret, SnukExpr *loop) {
+static SnukValue execute_while_expr(SnukInterpreter *intpret, SnukExpr *loop, bool weak_ref) {
     SnukValue res = {.type = SNUK_VALUE_NULL};
     SnukValue cond = {.type = SNUK_VALUE_NULL};
 
 loop_start:
     if (loop->type == SNUK_EXPR_WHILE) {
         snuk_value_free(cond);
-        cond = snuk_interpreter_eval_expr(intpret, loop->while_loop.condition);
+        cond = interpreter_eval_expr(intpret, loop->while_loop.condition, weak_ref);
         if (!snuk_value_is_true(cond)) goto end;
     }
 
     snuk_value_free(res);
-    res = execute_block_expr(intpret, loop->while_loop.body, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL);
+    res = execute_block_expr(intpret, loop->while_loop.body, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL, weak_ref);
 
     switch (intpret->signal) {
         case SNUK_SIGNAL_RETURN:
@@ -750,7 +633,7 @@ loop_start:
 
     if (loop->type == SNUK_EXPR_DO_WHILE) {
         snuk_value_free(cond);
-        cond = snuk_interpreter_eval_expr(intpret, loop->while_loop.condition);
+        cond = interpreter_eval_expr(intpret, loop->while_loop.condition, weak_ref);
         if (!snuk_value_is_true(cond)) goto end;
     }
 
@@ -765,25 +648,25 @@ end:
  * @brief Execute a for loop within its own scope, running the init, condition,
  * body, and update steps.
  */
-static SnukValue execute_for_expr(SnukInterpreter *intpret, SnukExpr *loop) {
+static SnukValue execute_for_expr(SnukInterpreter *intpret, SnukExpr *loop, bool weak_ref) {
     interpreter_push_scope(intpret);
     SnukValue res = {.type = SNUK_VALUE_NULL};
     SnukValue cond = {.type = SNUK_VALUE_NULL};
 
     if (loop->for_loop.init) {
-        SnukValue val = snuk_interpreter_exec_item(intpret, loop->for_loop.init);
+        SnukValue val = interpreter_exec_item(intpret, loop->for_loop.init, false);
         snuk_value_free(val);
     }
 
 loop_start:
     if (loop->for_loop.condition) {
         snuk_value_free(cond);
-        cond = snuk_interpreter_eval_expr(intpret, loop->for_loop.condition);
+        cond = interpreter_eval_expr(intpret, loop->for_loop.condition, false);
         if (!snuk_value_is_true(cond)) goto end;
     }
 
     snuk_value_free(res);
-    res = execute_block_expr(intpret, loop->for_loop.body, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL);
+    res = execute_block_expr(intpret, loop->for_loop.body, SNUK_SIGNAL_NONE, SNUK_SIGNAL_ALL, false);
 
     switch (intpret->signal) {
         case SNUK_SIGNAL_RETURN:
@@ -805,7 +688,7 @@ loop_start:
     }
 
     if (loop->for_loop.update) {
-        SnukValue val = snuk_interpreter_eval_expr(intpret, loop->for_loop.update);
+        SnukValue val = interpreter_eval_expr(intpret, loop->for_loop.update, false);
         snuk_value_free(val);
     }
 
@@ -813,25 +696,38 @@ loop_start:
 
 end:
     snuk_value_free(cond);
+
+    SnukRefCounter *new_scope = snuk_ref_counter_retain(intpret->current);
     interpreter_pop_scope(intpret);
+
+    if (weak_ref) snuk_scope_downgrade_parent(new_scope);
+
+    snuk_ref_counter_release(&new_scope);
+
     return res;
 }
 
-static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *expr) {
+static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref) {
     interpreter_push_scope(intpret);
 
     uint64_t count = snuk_darray_get_length(expr->type_expr.members);
     for (uint64_t i = 0; i < count; ++i) {
-        SnukValue val = snuk_interpreter_exec_item(intpret, expr->type_expr.members[i]);
+        SnukValue val = interpreter_exec_item(intpret, expr->type_expr.members[i], true);
         snuk_value_free(val);
     }
 
     SnukValue value = {
         .type = SNUK_VALUE_TYPE,
-        .type_value = {.type = expr->type_expr.type, .closure = snuk_ref_counter_retain(intpret->current)}
+        .type_value = {
+            .type = expr->type_expr.type,
+            .closure = snuk_ref_counter_retain(intpret->current),
+            .weak_ref = false,
+        },
     };
 
     interpreter_pop_scope(intpret);
+
+    if (weak_ref) snuk_scope_downgrade_parent(value.type_value.closure);
 
     // Syntax sugar
     if (expr->type_expr.name.len)
@@ -841,8 +737,8 @@ static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *ex
     return value;
 }
 
-static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr) {
-    SnukValue type = snuk_interpreter_get_env(intpret, expr->type_inst_expr.type->name);
+static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukValue type, SnukExpr *expr, bool weak_ref) {
+    SNUK_UNUSED(weak_ref);
     SNUK_ASSERT(type.type == SNUK_VALUE_TYPE, "type instance creation expression on non type");
 
     interpreter_push_scope(intpret);
@@ -851,25 +747,18 @@ static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr)
     uint64_t member_count = snuk_darray_get_length(type_scope->vars);
     for (uint64_t i = 0; i < member_count; ++i) {
         SnukEnv *type_env = type_scope->vars[i];
-
         SnukValue value = snuk_value_copy(type_env->value);
-        SnukScope *scope;
         // When instance is created, things will hold instance as their parent, except the type
         // instance, which still holds it's type as parent
         switch (value.type) {
             case SNUK_VALUE_FN:
-                scope = GET_SCOPE(value.fn_value.closure);
-                snuk_ref_counter_release(&scope->parent);
-                scope->parent = snuk_ref_counter_retain(intpret->current);
+                snuk_scope_set_parent(
+                    value.fn_value.closure, snuk_ref_counter_retain_weak(intpret->current), true);
                 break;
 
             case SNUK_VALUE_TYPE:
-                scope = GET_SCOPE(value.type_value.closure);
-                snuk_ref_counter_release(&scope->parent);
-                scope->parent = snuk_ref_counter_retain(intpret->current);
-                break;
-
-            case SNUK_VALUE_TYPE_INST:
+                snuk_scope_set_parent(
+                    value.type_value.closure, snuk_ref_counter_retain_weak(intpret->current), true);
                 break;
 
             default:
@@ -889,28 +778,24 @@ static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr)
         SnukEnv *env = snuk_scope_lookup(intpret->current, name);
         SNUK_ASSERT(env, "member doesn't exists");
 
-        SnukValue value = snuk_interpreter_eval_expr(intpret, assign->assign.value);
+        SnukValue value = interpreter_eval_expr(intpret, assign->assign.value, true);
         SNUK_ASSERT(snuk_interpreter_set_env(intpret, name, value), "something went wrong");
         snuk_value_free(value);
     }
-
-    // Retain new scope
-    SnukRefCounter *new_scope = snuk_ref_counter_retain(intpret->current);
 
     SnukValue value = {
         .type = SNUK_VALUE_TYPE_INST,
         .type_value = {
             .type = expr->type_inst_expr.type,
-            .closure = snuk_ref_counter_retain(new_scope),
+            .closure = snuk_ref_counter_retain(intpret->current),
+            .weak_ref = false,
         },
     };
 
     interpreter_pop_scope(intpret);
 
     // Reparent
-    SnukScope *new_sc = GET_SCOPE(new_scope);
-    snuk_ref_counter_release(&new_sc->parent);
-    new_sc->parent = snuk_ref_counter_retain(type.type_value.closure);
+    snuk_scope_set_parent(value.type_value.closure, snuk_ref_counter_retain(type.type_value.closure), false);
 
     // Syntax sugar
     if (expr->type_inst_expr.name.len)
@@ -918,15 +803,12 @@ static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr)
                         intpret, expr->type_inst_expr.name, value.type_value.type, value, false),
                     "type instance name already exists");
 
-    snuk_value_free(type);
-    snuk_ref_counter_release(&new_scope);
-
     return value;
 }
 
-static SnukValue
-    get_binary_op_value(SnukInterpreter *intpret, SnukValue lhs, SnukExpr *rhs_expr, SnukTokenType op) {
-    SnukValue rhs = snuk_interpreter_eval_expr(intpret, rhs_expr);
+static SnukValue get_binary_op_value(
+    SnukInterpreter *intpret, SnukValue lhs, SnukExpr *rhs_expr, SnukTokenType op, bool weak_ref) {
+    SnukValue rhs = interpreter_eval_expr(intpret, rhs_expr, weak_ref);
     SnukTokenType op_type;
     switch (op) {
         case SNUK_TOKEN_PLUS_ASSIGN:
@@ -969,55 +851,8 @@ static SnukValue
     return res;
 }
 
-typedef struct PredefinedTypes {
-    const char *type;
-    SnukValueType val_type;
-} PredefinedTypes;
-
-static PredefinedTypes pre_def_types[] = {
-    {.type = "int",   .val_type = SNUK_VALUE_INT   },
-    {.type = "float", .val_type = SNUK_VALUE_FLOAT },
-    {.type = "bool",  .val_type = SNUK_VALUE_BOOL  },
-    {.type = "str",   .val_type = SNUK_VALUE_STRING},
-};
-
-SNUK_INLINE SnukValueType get_predef_type(SnukStringView name) {
-    for (uint64_t i = 0; i < SNUK_ARRAY_LENGTH(pre_def_types); ++i)
-        if (snuk_string_view_equal_cstr(name, pre_def_types[i].type))
-            return pre_def_types[i].val_type;
-    return SNUK_VALUE_UNKOWN;
-}
-
-bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value, SnukType *type) {
-    if (value.type == SNUK_VALUE_NULL || type->type == TYPE_ANY) return true;
-
-    if (type->type == TYPE_FN && value.type == SNUK_VALUE_FN)
-        return snuk_type_equal(value.fn_value.type, type);
-
-    if (type->type == TYPE_TYPE && (value.type == SNUK_VALUE_TYPE || value.type == SNUK_VALUE_TYPE_INST))
-        return snuk_type_equal(value.type_value.type, type);
-
-    if (type->type == TYPE_NAMED) {
-        if (value.type == get_predef_type(type->name)) return true;
-
-        if (value.type == SNUK_VALUE_TYPE_INST) return snuk_type_equal(value.type_value.type, type);
-
-        if (value.type != SNUK_VALUE_TYPE) return false;
-
-        SnukEnv *env = interpreter_lookup(intpret, type->name);
-        if (!env) return false;
-
-        return snuk_type_equal(value.type_value.type, env->type);
-    }
-
-    return false;
-}
-
-static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_or_inst, SnukExpr *field) {
-    log_debug("debugging...", NULL);
-    snuk_value_log(type_or_inst);
-    snuk_expr_log(field);
-    log_debug("debugging end", NULL);
+static SnukValue execute_member_access(
+    SnukInterpreter *intpret, SnukValue type_or_inst, SnukExpr *field, bool weak_ref) {
     SNUK_ASSERT(type_or_inst.type == SNUK_VALUE_TYPE || type_or_inst.type == SNUK_VALUE_TYPE_INST, "something is wrong");
     SnukValue res = (SnukValue){.type = SNUK_VALUE_UNKOWN};
     SnukStringView field_name = {0};
@@ -1047,7 +882,7 @@ static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_
                             "declared!");
             }
 
-            res = execute_call_expr(intpret, env->value, field->call.params);
+            res = execute_call_expr(intpret, env->value, field->call.params, weak_ref);
             if (type_or_inst.type == SNUK_VALUE_TYPE_INST) {
                 // Remove self
                 snuk_scope_remove_env(env->value.fn_value.closure, self);
@@ -1063,7 +898,7 @@ static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_
             field_name = field->member_access.type->identifier;
             env = snuk_scope_lookup(type_or_inst.type_value.closure, field_name);
             SNUK_ASSERT(env, "field doesn't exists");
-            res = execute_member_access(intpret, env->value, field->member_access.field);
+            res = execute_member_access(intpret, env->value, field->member_access.field, weak_ref);
             break;
         }
 
@@ -1072,7 +907,7 @@ static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_
             field_name = field->binary.left->identifier;
             env = snuk_scope_lookup(type_or_inst.type_value.closure, field_name);
             SNUK_ASSERT(env, "field doesn't exists");
-            res = execute_binary_op(intpret, env->value, field->binary.right, field->binary.op);
+            res = execute_binary_op(intpret, env->value, field->binary.right, field->binary.op, weak_ref);
             break;
 
         case SNUK_EXPR_UNARY:
@@ -1090,9 +925,8 @@ static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_
             field_name = field->assign.identifier->identifier;
             env = snuk_scope_lookup(type_or_inst.type_value.closure, field_name);
             SNUK_ASSERT(env, "field doesn't exists");
-            res = snuk_interpreter_eval_expr(intpret, field->assign.value);
-            snuk_value_free(env->value);
-            env->value = snuk_value_copy(res);
+            res = interpreter_eval_expr(intpret, field->assign.value, weak_ref);
+            snuk_env_assign_value(env, res);
             break;
 
         case SNUK_EXPR_COMPOUND_ASSIGN:
@@ -1104,9 +938,8 @@ static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_
             env = snuk_scope_lookup(type_or_inst.type_value.closure, field_name);
             SNUK_ASSERT(env, "field doesn't exists");
             res = get_binary_op_value(
-                intpret, env->value, field->compound_assign.value, field->compound_assign.op);
-            snuk_value_free(env->value);
-            env->value = snuk_value_copy(res);
+                intpret, env->value, field->compound_assign.value, field->compound_assign.op, weak_ref);
+            snuk_env_assign_value(env, res);
             break;
 
         default:
@@ -1117,14 +950,14 @@ static SnukValue execute_member_access(SnukInterpreter *intpret, SnukValue type_
     return res;
 }
 
-static SnukValue execute_fn_expr(SnukInterpreter *intpret, SnukExpr *expr) {
+static SnukValue execute_fn_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref) {
     interpreter_push_scope(intpret);
 
     uint64_t param_count = snuk_darray_get_length(expr->fn_expr.params);
     for (uint64_t i = 0; i < param_count; ++i) {
         SnukVar *param = expr->fn_expr.params[i];
         SnukValue value = (SnukValue){.type = SNUK_VALUE_UNKOWN};
-        if (param->value) value = snuk_interpreter_eval_expr(intpret, param->value);
+        if (param->value) value = interpreter_eval_expr(intpret, param->value, false);
         SNUK_ASSERT(snuk_interpreter_create_env(intpret, param->name, param->type, value, false),
                     "duplicate parameter names");
         snuk_value_free(value);
@@ -1134,12 +967,15 @@ static SnukValue execute_fn_expr(SnukInterpreter *intpret, SnukExpr *expr) {
         .type = SNUK_VALUE_FN,
         .fn_value = {
             .closure = snuk_ref_counter_retain(intpret->current),
+            .weak_ref = false,
             .body = expr->fn_expr.body,
             .type = expr->fn_expr.type,
         },
     };
 
     interpreter_pop_scope(intpret);
+
+    if (weak_ref) snuk_scope_downgrade_parent(value.fn_value.closure);
 
     // Syntax sugar
     if (expr->fn_expr.name.len)
@@ -1153,7 +989,8 @@ static SnukValue execute_fn_expr(SnukInterpreter *intpret, SnukExpr *expr) {
  * @brief Bind call arguments to a function's parameters in a new scope and
  * execute its body.
  */
-static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukValue fn, SnukExpr **params) {
+static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukValue fn, SnukExpr **params, bool weak_ref) {
+    SNUK_UNUSED(weak_ref);
     SNUK_ASSERT(fn.type == SNUK_VALUE_FN, "call expression on non function");
 
     interpreter_push_scope(intpret);
@@ -1187,7 +1024,7 @@ static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukValue fn, SnukE
             SNUK_SHOULD_NOT_REACH_HERE;
         }
 
-        SnukValue val = snuk_interpreter_eval_expr(intpret, value);
+        SnukValue val = interpreter_eval_expr(intpret, value, false);
         SNUK_ASSERT(snuk_interpreter_create_env(intpret, name, type, val, false),
                     "duplicate "
                     "parameter");
@@ -1213,33 +1050,30 @@ static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukValue fn, SnukE
     interpreter_pop_scope(intpret);
 
     // Release parent and hold the closure
-    SnukScope *new_sc = GET_SCOPE(new_scope);
-    snuk_ref_counter_release(&new_sc->parent);
-    new_sc->parent = snuk_ref_counter_retain(fn.fn_value.closure);
+    snuk_scope_set_parent(new_scope, snuk_ref_counter_retain(fn.fn_value.closure), false);
 
     SnukRefCounter *temp = snuk_ref_counter_move(&intpret->current);
     intpret->current = snuk_ref_counter_move(&new_scope);
 
-    SnukValue ret = execute_block_expr(intpret, fn.fn_value.body, SNUK_SIGNAL_RETURN, SNUK_SIGNAL_NONE);
+    SnukValue ret = execute_block_expr(intpret, fn.fn_value.body, SNUK_SIGNAL_RETURN, SNUK_SIGNAL_NONE, false);
 
     new_scope = snuk_ref_counter_move(&intpret->current);
     intpret->current = snuk_ref_counter_move(&temp);
 
-    snuk_ref_counter_release(&new_sc->parent);
     snuk_ref_counter_release(&new_scope);
 
     return ret;
 }
 
-static SnukValue
-    execute_binary_op(SnukInterpreter *intpret, SnukValue left, SnukExpr *right_expr, SnukTokenType op) {
+static SnukValue execute_binary_op(
+    SnukInterpreter *intpret, SnukValue left, SnukExpr *right_expr, SnukTokenType op, bool weak_ref) {
     SnukValue right;
     switch (op) {
         case SNUK_TOKEN_PIPE_PIPE:
         case SNUK_TOKEN_KW_OR: {
             bool bool_value = snuk_value_is_true(left);
             if (!bool_value) {
-                right = snuk_interpreter_eval_expr(intpret, right_expr);
+                right = interpreter_eval_expr(intpret, right_expr, weak_ref);
                 bool_value = snuk_value_is_true(right);
                 snuk_value_free(right);
             }
@@ -1254,7 +1088,7 @@ static SnukValue
         case SNUK_TOKEN_KW_AND: {
             bool bool_value = snuk_value_is_true(left);
             if (bool_value) {
-                right = snuk_interpreter_eval_expr(intpret, right_expr);
+                right = interpreter_eval_expr(intpret, right_expr, weak_ref);
                 bool_value = snuk_value_is_true(right);
                 snuk_value_free(right);
             }
@@ -1269,8 +1103,181 @@ static SnukValue
             break;
     }
 
-    right = snuk_interpreter_eval_expr(intpret, right_expr);
+    right = interpreter_eval_expr(intpret, right_expr, weak_ref);
     SnukValue res = perform_binary_op(left, right, op);
     snuk_value_free(right);
     return res;
+}
+
+static SnukValue interpreter_exec_item(SnukInterpreter *intpret, SnukItem *item, bool weak_ref) {
+    switch (item->type) {
+        case SNUK_ITEM_EXPR:
+            return interpreter_eval_expr(intpret, item->expr, weak_ref);
+
+        case SNUK_ITEM_VAR_DECL:
+        case SNUK_ITEM_CONST_DECL: {
+            SnukValue value = interpreter_eval_expr(intpret, item->var->value, weak_ref);
+            SNUK_ASSERT(snuk_interpreter_create_env(intpret, item->var->name, item->var->type,
+                                                    value, item->type == SNUK_ITEM_CONST_DECL),
+                        "duplicate variable");
+            return value;
+        }
+
+        case SNUK_ITEM_PRINT:
+            execute_print_item(intpret, item->print_exprs, weak_ref);
+            // TODO: return something else?
+            return (SnukValue){.type = SNUK_VALUE_NULL};
+            break;
+
+        // TODO:
+        case SNUK_ITEM_RETURN:
+        case SNUK_ITEM_BREAK: {
+            SnukValue value = {.type = SNUK_VALUE_NULL};
+            if (item->expr) value = interpreter_eval_expr(intpret, item->expr, weak_ref);
+            intpret->signal = item->type == SNUK_ITEM_RETURN ? SNUK_SIGNAL_RETURN : SNUK_SIGNAL_BREAK;
+            return value;
+        }
+        case SNUK_ITEM_CONTINUE:
+            intpret->signal = SNUK_SIGNAL_CONTINUE;
+            return (SnukValue){.type = SNUK_VALUE_NULL};
+
+        case SNUK_ITEM_MAX:
+        default:
+            break;
+    }
+
+    SNUK_SHOULD_NOT_REACH_HERE;
+    return (SnukValue){.type = SNUK_VALUE_UNKOWN};
+}
+
+static SnukValue interpreter_eval_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref) {
+    switch (expr->type) {
+        case SNUK_EXPR_IDENTIFIER:
+            return snuk_interpreter_get_env(intpret, expr->identifier);
+
+        case SNUK_EXPR_INT:
+            return (SnukValue){
+                .type = SNUK_VALUE_INT,
+                .int_value = expr->int_literal,
+            };
+
+        case SNUK_EXPR_FLOAT:
+            return (SnukValue){
+                .type = SNUK_VALUE_FLOAT,
+                .float_value = expr->float_literal,
+            };
+
+        case SNUK_EXPR_STRING:
+            return (SnukValue){
+                .type = SNUK_VALUE_STRING,
+                .string_value = expr->string_literal,
+            };
+
+        case SNUK_EXPR_BOOL:
+            return (SnukValue){
+                .type = SNUK_VALUE_BOOL,
+                .bool_value = expr->bool_literal,
+            };
+
+        case SNUK_EXPR_NULL:
+            return (SnukValue){
+                .type = SNUK_VALUE_NULL,
+            };
+
+        case SNUK_EXPR_UNARY: {
+            SnukValue val = interpreter_eval_expr(intpret, expr->unary.operand, weak_ref);
+            SnukValue ret = execute_unary_op(val, expr->unary.op);
+            snuk_value_free(val);
+            return ret;
+        }
+
+        case SNUK_EXPR_BINARY: {
+            SnukValue left = interpreter_eval_expr(intpret, expr->binary.left, weak_ref);
+            SnukValue res = execute_binary_op(intpret, left, expr->binary.right, expr->binary.op, weak_ref);
+            snuk_value_free(left);
+
+            return res;
+        }
+
+        case SNUK_EXPR_ASSIGN: {
+            SnukValue value = interpreter_eval_expr(intpret, expr->assign.value, weak_ref);
+            SNUK_ASSERT(snuk_interpreter_set_env(intpret, expr->assign.identifier->identifier, value),
+                        "failed to set value");
+            return value;
+        }
+
+        case SNUK_EXPR_COMPOUND_ASSIGN: {
+            SnukValue lhs = interpreter_eval_expr(intpret, expr->compound_assign.identifier, weak_ref);
+            SnukValue res = get_binary_op_value(
+                intpret, lhs, expr->compound_assign.value, expr->compound_assign.op, weak_ref);
+            snuk_value_free(lhs);
+            SNUK_ASSERT(snuk_interpreter_set_env(intpret, expr->compound_assign.identifier->identifier, res),
+                        "failed to set value");
+            return res;
+        }
+
+        case SNUK_EXPR_IF:
+            return execute_if_expr(intpret, expr, weak_ref);
+
+        // TODO: match
+        case SNUK_EXPR_MATCH:
+            break;
+
+        case SNUK_EXPR_WHILE:
+        case SNUK_EXPR_DO_WHILE:
+            return execute_while_expr(intpret, expr, weak_ref);
+
+        case SNUK_EXPR_FOR:
+            return execute_for_expr(intpret, expr, weak_ref);
+
+        case SNUK_EXPR_FN:
+            return execute_fn_expr(intpret, expr, weak_ref);
+
+        case SNUK_EXPR_TYPE:
+            return execute_type_declaration(intpret, expr, weak_ref);
+
+        case SNUK_EXPR_TYPE_INST: {
+            SnukValue type = snuk_interpreter_get_env(intpret, expr->type_inst_expr.type->name);
+            SnukValue ret = execute_inst_creation(intpret, type, expr, weak_ref);
+            snuk_value_free(type);
+            return ret;
+        }
+
+        case SNUK_EXPR_BLOCK:
+            return execute_block_expr(intpret, expr, SNUK_SIGNAL_BREAK, SNUK_SIGNAL_NONE, weak_ref);
+
+        case SNUK_EXPR_CALL: {
+            SnukValue fn = interpreter_eval_expr(intpret, expr->call.fn, weak_ref);
+            SnukValue ret = execute_call_expr(intpret, fn, expr->call.params, weak_ref);
+            snuk_value_free(fn);
+            return ret;
+        }
+
+        case SNUK_EXPR_MEMBER: {
+            SnukValue type_or_inst = interpreter_eval_expr(intpret, expr->member_access.type, weak_ref);
+            SnukValue ret = execute_member_access(intpret, type_or_inst, expr->member_access.field, weak_ref);
+            snuk_value_free(type_or_inst);
+            return ret;
+        }
+
+        case SNUK_EXPR_SELF: {
+            SnukStringView self = snuk_string_view_create_with_len("self", 4);
+            SnukValue self_value = snuk_interpreter_get_env(intpret, self);
+            SNUK_ASSERT(self_value.type == SNUK_VALUE_TYPE_INST, "self error");
+            return self_value;
+        }
+
+        case SNUK_EXPR_INDEX:
+        case SNUK_EXPR_LIST:
+        case SNUK_EXPR_LINE_COMMENT:
+        case SNUK_EXPR_BLOCK_COMMENT:
+            return (SnukValue){.type = SNUK_VALUE_NULL};
+
+        case SNUK_EXPR_MAX:
+        default:
+            break;
+    }
+
+    SNUK_SHOULD_NOT_REACH_HERE;
+    return (SnukValue){.type = SNUK_VALUE_UNKOWN};
 }

--- a/src/interpreter/snuk_env.h
+++ b/src/interpreter/snuk_env.h
@@ -30,6 +30,11 @@ SNUK_INLINE SnukEnv *snuk_env_create(SnukStringView name, SnukType *type, SnukVa
     return env;
 }
 
+SNUK_INLINE void snuk_env_assign_value(SnukEnv *env, SnukValue value) {
+    snuk_value_free(env->value);
+    env->value = snuk_value_copy(value);
+}
+
 SNUK_INLINE void snuk_env_free(SnukEnv *env) {
     if (!env) return;
 

--- a/src/interpreter/snuk_scope.h
+++ b/src/interpreter/snuk_scope.h
@@ -5,7 +5,7 @@
 #include "snuk_env.h"
 
 #define GET_SCOPE(rc) ((SnukScope *)snuk_ref_counter_get(rc))
-#define GET_SCOPE_PARENT(rc) ((SnukRefCounter *)GET_SCOPE(rc)->parent)
+#define SCOPE_PARENT(rc) (GET_SCOPE(rc)->parent)
 
 typedef struct SnukScope SnukScope;
 
@@ -18,6 +18,7 @@ typedef struct SnukScope SnukScope;
 struct SnukScope {
     SnukEnv **vars;  // darray
     SnukRefCounter *parent;
+    bool weak_ref;
 };
 
 SNUK_INLINE void snuk_scope_destroy_envs(SnukScope *scope) {
@@ -48,7 +49,10 @@ SNUK_INLINE void snuk_scope_destroy(void *data, void *ptr) {
 
     snuk_darray_destroy(scope->vars);
 
-    if (scope->parent) snuk_ref_counter_release(&scope->parent);
+    if (scope->parent) {
+        if (scope->weak_ref) snuk_ref_counter_release_weak(&scope->parent);
+        else snuk_ref_counter_release(&scope->parent);
+    }
 
     snuk_free(scope);
 }
@@ -62,13 +66,39 @@ SNUK_INLINE void snuk_scope_destroy(void *data, void *ptr) {
  * @return Refcounted handle to the new scope, with snuk_scope_free as the
  * finalizer.
  */
-SNUK_INLINE SnukRefCounter *snuk_scope_create(SnukRefCounter *parent) {
+SNUK_INLINE SnukRefCounter *snuk_scope_create(SnukRefCounter *parent, bool weak_ref) {
     SnukScope *scope = (SnukScope *)snuk_alloc(sizeof(SnukScope), alignof(SnukScope));
     *scope = (SnukScope){
         .vars = snuk_darray_create(SnukEnv *, NULL),
         .parent = snuk_ref_counter_move(&parent),
+        .weak_ref = weak_ref,
     };
     return snuk_ref_counter_create(scope, NULL, snuk_scope_destroy);
+}
+
+SNUK_INLINE void snuk_scope_downgrade_parent(SnukRefCounter *scope_rc) {
+    SnukScope *scope = GET_SCOPE(scope_rc);
+    SNUK_ASSERT(!scope->weak_ref, "parent is already a weak pointer");
+    snuk_ref_counter_downgrade(scope->parent);
+    scope->weak_ref = true;
+}
+
+SNUK_INLINE void snuk_scope_release_parent(SnukRefCounter *scope_rc) {
+    SnukScope *scope = GET_SCOPE(scope_rc);
+    if (scope->parent) {
+        if (scope->weak_ref) snuk_ref_counter_release_weak(&scope->parent);
+        else snuk_ref_counter_release(&scope->parent);
+    }
+}
+
+SNUK_INLINE void snuk_scope_set_parent(SnukRefCounter *scope_rc, SnukRefCounter *parent, bool weak_ref) {
+    SnukScope *scope = GET_SCOPE(scope_rc);
+    if (scope->parent) {
+        if (scope->weak_ref) snuk_ref_counter_release_weak(&scope->parent);
+        else snuk_ref_counter_release(&scope->parent);
+    }
+    scope->parent = snuk_ref_counter_move(&parent);
+    scope->weak_ref = weak_ref;
 }
 
 /**
@@ -87,7 +117,7 @@ SNUK_INLINE SnukEnv *snuk_scope_lookup_recursive(SnukRefCounter *scope_rc, SnukS
     SnukEnv *env;
     while (scope_rc) {
         if ((env = snuk_scope_lookup(scope_rc, name))) return env;
-        scope_rc = GET_SCOPE_PARENT(scope_rc);
+        scope_rc = SCOPE_PARENT(scope_rc);
     }
     return NULL;
 }

--- a/src/interpreter/snuk_value.c
+++ b/src/interpreter/snuk_value.c
@@ -6,11 +6,15 @@
 SnukValue snuk_value_copy(SnukValue value) {
     switch (value.type) {
         case SNUK_VALUE_FN:
-            value.fn_value.closure = snuk_ref_counter_retain(value.fn_value.closure);
+            if (value.fn_value.weak_ref)
+                value.fn_value.closure = snuk_ref_counter_retain_weak(value.fn_value.closure);
+            else value.fn_value.closure = snuk_ref_counter_retain(value.fn_value.closure);
             break;
         case SNUK_VALUE_TYPE:
         case SNUK_VALUE_TYPE_INST:
-            value.type_value.closure = snuk_ref_counter_retain(value.type_value.closure);
+            if (value.type_value.weak_ref)
+                value.type_value.closure = snuk_ref_counter_retain_weak(value.type_value.closure);
+            else value.type_value.closure = snuk_ref_counter_retain(value.type_value.closure);
             break;
 
         case SNUK_VALUE_UNKOWN:
@@ -30,11 +34,13 @@ SnukValue snuk_value_copy(SnukValue value) {
 void snuk_value_free(SnukValue value) {
     switch (value.type) {
         case SNUK_VALUE_FN:
-            snuk_ref_counter_release(&value.fn_value.closure);
+            if (value.fn_value.weak_ref) snuk_ref_counter_release_weak(&value.fn_value.closure);
+            else snuk_ref_counter_release(&value.fn_value.closure);
             break;
         case SNUK_VALUE_TYPE:
         case SNUK_VALUE_TYPE_INST:
-            snuk_ref_counter_release(&value.type_value.closure);
+            if (value.type_value.weak_ref) snuk_ref_counter_release_weak(&value.type_value.closure);
+            else snuk_ref_counter_release(&value.type_value.closure);
             break;
 
         case SNUK_VALUE_UNKOWN:

--- a/src/interpreter/snuk_value.h
+++ b/src/interpreter/snuk_value.h
@@ -46,12 +46,14 @@ struct SnukValue {
 
         struct {
             SnukRefCounter *closure;
+            bool weak_ref;
             SnukExpr *body;
             SnukType *type;
         } fn_value;
 
         struct {
             SnukRefCounter *closure;
+            bool weak_ref;
             SnukType *type;
         } type_value;
     };

--- a/src/parser/snuk_expr.c
+++ b/src/parser/snuk_expr.c
@@ -550,7 +550,7 @@ static SnukExpr *parse_fn(SnukParser *parser) {
 
     parser_expect(parser, SNUK_TOKEN_LPAREN, "expected '('");
     while (!parser_match(parser, SNUK_TOKEN_RPAREN) && parser->current.type != SNUK_TOKEN_EOF) {
-        SnukVar *var = snuk_var_parse(parser);
+        SnukVar *var = snuk_var_parse(parser, false);
 
         fn_type = build_fn_type(parser, fn_type, var->type, NULL);
         snuk_darray_push(&params, var);

--- a/src/parser/snuk_item.c
+++ b/src/parser/snuk_item.c
@@ -61,7 +61,7 @@ static SnukItem *parse_expr_item(SnukParser *parser) {
 }
 
 static SnukItem *parse_decl_item(SnukParser *parser, bool is_const) {
-    SnukVar *var = snuk_var_parse(parser);
+    SnukVar *var = snuk_var_parse(parser, true);
 
     parser_expect_item_end(parser);
 

--- a/src/parser/snuk_var.c
+++ b/src/parser/snuk_var.c
@@ -3,7 +3,7 @@
 #include "snuk_expr.h"
 #include "snuk_type.h"
 
-SnukVar *snuk_var_parse(SnukParser *parser) {
+SnukVar *snuk_var_parse(SnukParser *parser, bool default_null) {
     parser_expect(parser, SNUK_TOKEN_IDENTIFIER, "expected an identifier");
 
     SnukStringView name = parser->previous.string_literal;
@@ -14,7 +14,8 @@ SnukVar *snuk_var_parse(SnukParser *parser) {
 
     SnukExpr *value;
     if (parser_match(parser, SNUK_TOKEN_ASSIGN)) value = snuk_expr_parse(parser);
-    else value = build_null_expr(parser);
+    else if (default_null) value = build_null_expr(parser);
+    else value = NULL;
 
     return build_var(parser, name, type, value);
 }

--- a/src/parser/snuk_var.h
+++ b/src/parser/snuk_var.h
@@ -39,4 +39,4 @@ SNUK_INLINE SnukVar *build_var(SnukParser *parser, SnukStringView name, SnukType
 
 void snuk_var_log(SnukVar *var);
 
-SnukVar *snuk_var_parse(SnukParser *parser);
+SnukVar *snuk_var_parse(SnukParser *parser, bool default_null);

--- a/src/refcount.h
+++ b/src/refcount.h
@@ -54,8 +54,10 @@ SNUK_INLINE SnukRefCounter *snuk_ref_counter_retain_weak(SnukRefCounter *rc) {
 
 SNUK_INLINE void snuk_ref_counter_release(SnukRefCounter **rc) {
     SNUK_ASSERT(*rc, "SnukRefCounter is null");
+    SNUK_ASSERT((*rc)->strong_count, "releasing strong reference when no strong reference exists");
+
     log_debug("released a strong ref counter", NULL);
-    if ((*rc)->strong_count) (*rc)->strong_count--;
+    (*rc)->strong_count--;
 
     if ((*rc)->strong_count == 0) {
         (*rc)->free_fn((*rc)->data, (*rc)->mem);
@@ -63,17 +65,25 @@ SNUK_INLINE void snuk_ref_counter_release(SnukRefCounter **rc) {
         log_debug("ref counter held memory got destroyed", NULL);
     }
 
-    if ((*rc)->strong_count + (*rc)->weak_count == 0) snuk_free(*rc);
+    if ((*rc)->strong_count + (*rc)->weak_count == 0) {
+        snuk_free(*rc);
+        log_debug("a ref counter got destroyed", NULL);
+    }
 
     *rc = NULL;
 }
 
 SNUK_INLINE void snuk_ref_counter_release_weak(SnukRefCounter **rc) {
     SNUK_ASSERT(*rc, "SnukRefCounter is null");
-    log_debug("released a weak ref counter", NULL);
-    if ((*rc)->weak_count) (*rc)->weak_count--;
+    SNUK_ASSERT((*rc)->weak_count, "releasing weak reference when no weak reference exists");
 
-    if ((*rc)->strong_count + (*rc)->weak_count == 0) snuk_free(*rc);
+    log_debug("released a weak ref counter", NULL);
+    (*rc)->weak_count--;
+
+    if ((*rc)->strong_count + (*rc)->weak_count == 0) {
+        snuk_free(*rc);
+        log_debug("a ref counter got destroyed", NULL);
+    }
 
     *rc = NULL;
 }


### PR DESCRIPTION
## What does this PR do?

<!-- one or two sentences -->

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation
- [ ] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [ ] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [ ] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

<!-- optional — edge cases, open questions, related issues -->
Escaping all the assertions, somehow, some number of ref counter objects are destroyed than created.