### PR TITLE
feat(lexer): add extend keyword

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -79,6 +79,7 @@ KeyWord keywords[] = {
     {.keyword = "print",    .type = SNUK_TOKEN_PRINT   },
     {.keyword = "self",     .type = SNUK_TOKEN_SELF    },
     {.keyword = "type",     .type = SNUK_TOKEN_TYPE    },
+    {.keyword = "extend",   .type = SNUK_TOKEN_EXTEND  },
     {.keyword = "or",       .type = SNUK_TOKEN_KW_OR   },
     {.keyword = "and",      .type = SNUK_TOKEN_KW_AND  },
     {.keyword = "not",      .type = SNUK_TOKEN_KW_NOT  },
@@ -766,6 +767,8 @@ const char *snuk_lexer_token_type_to_string(SnukTokenType type) {
             return SNUK_STRINGIFY(SNUK_TOKEN_FN);
         case SNUK_TOKEN_TYPE:
             return SNUK_STRINGIFY(SNUK_TOKEN_TYPE);
+        case SNUK_TOKEN_EXTEND:
+            return SNUK_STRINGIFY(SNUK_TOKEN_EXTEND);
         case SNUK_TOKEN_SELF:
             return SNUK_STRINGIFY(SNUK_TOKEN_SELF);
         case SNUK_TOKEN_PRINT:

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -45,6 +45,7 @@ typedef enum SnukTokenType {
     SNUK_TOKEN_CONTINUE,
     SNUK_TOKEN_FN,
     SNUK_TOKEN_TYPE,
+    SNUK_TOKEN_EXTEND,
     SNUK_TOKEN_SELF,
     SNUK_TOKEN_PRINT,
 


### PR DESCRIPTION
Closes #147

Adds the `extend` keyword to the Snuk lexer for future OOP features.

Changes:
- Add `SNUK_TOKEN_EXTEND` to token enum in `src/lexer.h`
- Add keyword entry in `src/lexer.c` (properly clang-format aligned)
- Add token type string conversion

Note: PR #152 was closed and replaced by this PR due to clang-format alignment issues in the original.