### PR TITLE
feat: update the typing system

### DIFF
--- a/include/snuk/interpreter/interpreter.h
+++ b/include/snuk/interpreter/interpreter.h
@@ -83,5 +83,3 @@ bool snuk_interpreter_create_env(
     SnukInterpreter *intpret, SnukStringView name, SnukType *type, SnukValue value, bool is_const);
 
 bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value, SnukType *type);
-
-bool snuk_interpreter_type_is_of_interface(SnukInterpreter *intpret, SnukValue type, SnukValue interface);

--- a/include/snuk/interpreter/snuk_value.h
+++ b/include/snuk/interpreter/snuk_value.h
@@ -70,7 +70,7 @@ struct SnukValue {
         } type_value;
 
         struct {
-            SnukItem **members;
+            SnukType *type;
         } interface;
     };
 };

--- a/include/snuk/parser/snuk_item.h
+++ b/include/snuk/parser/snuk_item.h
@@ -51,7 +51,6 @@ struct SnukItem {
 
         struct {
             SnukStringView name;
-            SnukItem **members;
             SnukType *type;
         } interface_item;
     };
@@ -187,20 +186,19 @@ SNUK_INLINE SnukItem *build_extend_item(SnukParser *parser, SnukItem *item, Snuk
 
 /**
  * @brief Build a interface item.
+ *
  * @param parser Parser context to operate on.
  * @param name Name of the interface.
- * @param members Members of the interface.
  *
  * @return Extend item.
  */
-SNUK_INLINE SnukItem *build_interface_item(SnukParser *parser, SnukStringView name, SnukItem **members) {
+SNUK_INLINE SnukItem *build_interface_item(SnukParser *parser, SnukStringView name, SnukType *type) {
     SnukItem *item = parser_create_item(parser);
     *item = (SnukItem){
         .type = SNUK_ITEM_INTERFACE,
         .interface_item = {
             .name = parser_copy_string_view(parser, name),
-            .members = members,
-            .type = build_interface_type(parser, name),
+            .type = type,
         },
     };
     return item;

--- a/include/snuk/parser/snuk_type.h
+++ b/include/snuk/parser/snuk_type.h
@@ -11,67 +11,30 @@
 struct SnukType {
     enum {
         TYPE_ANY, /**< No type annotation */
+        TYPE_TYPE, /**< Type type */
         TYPE_NAMED, /**< Named type */
         TYPE_FN, /**< Function type */
-        TYPE_TYPE, /**< Type type */
-        TYPE_INTERFACE,
+        TYPE_INTERFACE, /**< Interface type */
 
         TYPE_MAX, /**< Sentinel value for type kinds. */
     } type;
 
     union {
-        SnukStringView name; /**< Type name (for named parameters) */
+        SnukStringView name; /**< Type name */
 
         struct {
-            SnukType *return_type; /**< The return type of function */
             SnukType **param_types; /**< Darray of parameter types */
+            SnukType *return_type; /**< The return type of function */
         } fn;
 
-        SnukType **member_types; /**< Darray of type of the members */
+        SnukVar **members; /**< Members of the inerface */
     };
 };
 
 extern SnukType any_type;
+extern SnukType type_type;
 
-SNUK_INLINE bool snuk_type_equal(SnukType *type1, SnukType *type2) {
-    if (type1->type != type2->type) return false;
-
-    uint64_t count1;
-    uint64_t count2;
-    switch (type1->type) {
-        case TYPE_ANY:
-            return true;
-
-        case TYPE_NAMED:
-            return snuk_string_view_equal(type1->name, type2->name);
-
-        case TYPE_FN:
-            if (!snuk_type_equal(type1->fn.return_type, type2->fn.return_type)) return false;
-
-            count1 = snuk_darray_get_length(type1->fn.param_types);
-            count2 = snuk_darray_get_length(type2->fn.param_types);
-            if (count1 != count2) return false;
-
-            for (uint64_t i = 0; i < count1; ++i)
-                if (!snuk_type_equal(type1->fn.param_types[i], type2->fn.param_types[i]))
-                    return false;
-            return true;
-
-        case TYPE_TYPE:
-            count1 = snuk_darray_get_length(type1->member_types);
-            count2 = snuk_darray_get_length(type2->member_types);
-            if (count1 != count2) return false;
-            for (uint64_t i = 0; i < count1; ++i)
-                if (!snuk_type_equal(type1->member_types[i], type2->member_types[i])) return false;
-
-            return true;
-
-        default:
-            SNUK_SHOULD_NOT_REACH_HERE;
-            break;
-    }
-    return false;
-}
+bool snuk_type_equal(SnukType *type1, SnukType *type2);
 
 /**
  * @brief Allocate a type node.
@@ -97,6 +60,18 @@ SNUK_INLINE SnukType *parser_create_type(SnukParser *parser) {
 SNUK_INLINE SnukType *build_any_type(SnukParser *parser) {
     SNUK_UNUSED(parser);
     return &any_type;
+}
+
+/**
+ * @brief Build a type type.
+ *
+ * @param parser Parser context to operate on.
+ *
+ * @return Newly allocated type node.
+ */
+SNUK_INLINE SnukType *build_type_type(SnukParser *parser) {
+    SNUK_UNUSED(parser);
+    return &type_type;
 }
 
 /**
@@ -141,33 +116,17 @@ SNUK_INLINE SnukType *build_fn_type(SnukParser *parser, SnukType *type, SnukType
     return type;
 }
 
-/**
- * @brief Build a type type.
- *
- * @param parser Parser context to operate on.
- * @param type Existing type type to append member type or NULL to create one.
- * @param member_type The member type to append.
- *
- * @return Newly allocated type node.
- */
-SNUK_INLINE SnukType *build_type_type(SnukParser *parser, SnukType *type, SnukType *member_type) {
+SNUK_INLINE SnukType *build_interface_type(SnukParser *parser, SnukType *type, SnukVar *member) {
     if (!type) {
         type = parser_create_type(parser);
         *type = (SnukType){
-            .type = TYPE_TYPE,
-            .member_types = snuk_darray_create(SnukType *, parser->allocator),
+            .type = TYPE_INTERFACE,
+            .members = snuk_darray_create(SnukVar *, parser->allocator),
         };
     }
-    if (member_type) snuk_darray_push(&type->member_types, member_type);
-    return type;
-}
 
-SNUK_INLINE SnukType *build_interface_type(SnukParser *parser, SnukStringView name) {
-    SnukType *type = parser_create_type(parser);
-    *type = (SnukType){
-        .type = TYPE_INTERFACE,
-        .name = parser_copy_string_view(parser, name),
-    };
+    if (member) snuk_darray_push(&type->members, member);
+
     return type;
 }
 
@@ -179,6 +138,8 @@ SNUK_INLINE SnukType *build_interface_type(SnukParser *parser, SnukStringView na
  * @return Parsed type, or NULL on parse failure.
  */
 SnukType *snuk_type_parse(SnukParser *parser);
+
+SnukType *snuk_type_parse_interface(SnukParser *parser);
 
 /**
  * @brief Log a parsed type annotation.

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -136,18 +136,12 @@ void snuk_interpreter_deinit(SnukInterpreter *intpret) {
 
 bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value, SnukType *type) {
     // in case of parameter without default value, value will be unknown
-    if (value.type == SNUK_VALUE_UNKOWN) return true;
+    if (value.type == SNUK_VALUE_UNKOWN || value.type == SNUK_VALUE_NULL) return true;
 
-    if (value.type == SNUK_VALUE_NULL || type->type == TYPE_ANY) return true;
+    if (type->type == TYPE_ANY) return true;
 
-    // TODO:
-    if (type->type == TYPE_INTERFACE && value.type == SNUK_VALUE_INTERFACE) return true;
-
-    if (type->type == TYPE_FN && value.type == SNUK_VALUE_FN)
-        return snuk_type_equal(value.fn_value.type, type);
-
-    if (type->type == TYPE_TYPE && (value.type == SNUK_VALUE_TYPE || value.type == SNUK_VALUE_TYPE_INST))
-        return snuk_type_equal(value.type_value.type, type);
+    if (type->type == TYPE_TYPE && value.type == SNUK_VALUE_TYPE)
+        return snuk_type_equal(type, value.type_value.type);
 
     if (type->type == TYPE_NAMED) {
         if (value.type == snuk_builtin_get_value_type(type->name)) return true;
@@ -156,37 +150,43 @@ bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value
         SnukEnv *env = interpreter_lookup(intpret, type->name);
         if (!env) return false;
 
-        if (env->type->type == TYPE_INTERFACE) {
-            SnukValue val;
-            if (value.type == SNUK_VALUE_TYPE_INST) {
-                SnukEnv *env = interpreter_lookup(intpret, value.type_value.type->name);
-                if (!env) return false;
-                val = env->value;
-            } else {
-                val = value;
-            }
-            return snuk_interpreter_type_is_of_interface(intpret, val, env->value);
-        }
+        if (env->type->type == TYPE_INTERFACE)
+            return snuk_interpreter_value_is_of_type(intpret, value, env->type);
 
-        if (value.type == SNUK_VALUE_TYPE) return snuk_type_equal(value.type_value.type, env->type);
-        else return snuk_type_equal(value.type_value.type, type);
+        if (value.type == SNUK_VALUE_TYPE_INST) return snuk_type_equal(type, value.type_value.type);
+
+        if (env->type->type == TYPE_TYPE)
+            // Must be having same closure
+            return env->value.type_value.closure == value.type_value.closure;
+
+        return false;
+    }
+
+    if (type->type == TYPE_FN && value.type == SNUK_VALUE_FN)
+        return snuk_type_equal(value.fn_value.type, type);
+
+    if (type->type == TYPE_INTERFACE) {
+        if (value.type == SNUK_VALUE_INTERFACE) return snuk_type_equal(type, value.interface.type);
+
+        if (value.type == SNUK_VALUE_TYPE || value.type == SNUK_VALUE_TYPE_INST) {
+            SnukVar **members = type->members;
+            uint64_t count = snuk_darray_get_length(members);
+            for (uint64_t i = 0; i < count; ++i) {
+                SnukEnv *member = snuk_scope_lookup(value.type_value.closure, members[i]->name);
+                if (!member && value.type_value.type_scope)
+                    member = snuk_scope_lookup(value.type_value.type_scope, members[i]->name);
+                if (!member) return false;
+                if (!snuk_interpreter_value_is_of_type(intpret, member->value, members[i]->type)) {
+                    return false;
+                }
+            }
+            return true;
+        }
 
         return false;
     }
 
     return false;
-}
-
-bool snuk_interpreter_type_is_of_interface(SnukInterpreter *intpret, SnukValue type, SnukValue interface) {
-    SnukItem **members = interface.interface.members;
-    uint64_t count = snuk_darray_get_length(members);
-    for (uint64_t i = 0; i < count; ++i) {
-        SnukEnv *env = snuk_scope_lookup(type.type_value.closure, members[i]->var->name);
-        if (!env) return false;
-        if (!snuk_interpreter_value_is_of_type(intpret, env->value, members[i]->var->type))
-            return false;
-    }
-    return true;
 }
 
 SnukValue snuk_interpreter_get_env(SnukInterpreter *intpret, SnukStringView name) {
@@ -480,6 +480,9 @@ static void interpreter_print_type(SnukType *type) {
         case TYPE_ANY:
             snuk_print("any", NULL);
             break;
+        case TYPE_TYPE:
+            snuk_print("type", NULL);
+            break;
 
         case TYPE_NAMED:
             snuk_print(SNUK_STRING_VIEW_FORMAT, SNUK_STRING_VIEW_ARG(type->name));
@@ -496,14 +499,14 @@ static void interpreter_print_type(SnukType *type) {
             interpreter_print_type(type->fn.return_type);
             break;
 
-        case TYPE_TYPE:
-            snuk_print("type {", NULL);
-            count = snuk_darray_get_length(type->member_types);
+        case TYPE_INTERFACE:
+            snuk_print("interface", NULL);
+            count = snuk_darray_get_length(type->members);
             for (uint64_t i = 0; i < count; ++i) {
-                if (i != 0) snuk_print(", ", NULL);
-                interpreter_print_type(type->member_types[i]);
+                if (i != 0) snuk_print("; ", NULL);
+                snuk_print(SNUK_STRING_VIEW_FORMAT ": ", SNUK_STRING_VIEW_ARG(type->members[i]->name));
+                interpreter_print_type(type->members[i]->type);
             }
-            snuk_print("}", NULL);
             break;
 
         default:
@@ -1319,7 +1322,7 @@ static SnukValue execute_interface(SnukInterpreter *intpret, SnukItem *item, boo
     SnukValue value = {
         .type = SNUK_VALUE_INTERFACE,
         .interface = {
-            .members = item->interface_item.members,
+            .type = item->interface_item.type,
         },
     };
     SNUK_ASSERT(snuk_interpreter_create_env(

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -500,6 +500,7 @@ static bool lexer_should_insert_vsemicolon(SnukLexer *lexer) {
         case SNUK_TOKEN_NAN:
         case SNUK_TOKEN_INF:
         case SNUK_TOKEN_ANY:  // after the type annotation
+        case SNUK_TOKEN_TYPE:  // after the type annotation
         case SNUK_TOKEN_RETURN:
         case SNUK_TOKEN_BREAK:
         case SNUK_TOKEN_CONTINUE:

--- a/src/parser/snuk_expr.c
+++ b/src/parser/snuk_expr.c
@@ -636,33 +636,12 @@ static SnukExpr *parse_type(SnukParser *parser, SnukStringView name) {
     parser_expect(parser, SNUK_TOKEN_LBRACE, "expected '{'");
 
     SnukItem **members = snuk_darray_create(SnukItem *, parser->allocator);
-    SnukType *type_type = build_type_type(parser, NULL, NULL);
+    SnukType *type_type = build_type_type(parser);
 
     while (!parser_match(parser, SNUK_TOKEN_RBRACE) && parser->current.type != SNUK_TOKEN_EOF) {
         if (parser_check(parser, SNUK_TOKEN_VAR) || parser_check(parser, SNUK_TOKEN_CONST)
             || parser_check(parser, SNUK_TOKEN_FN) || parser_check(parser, SNUK_TOKEN_TYPE)) {
             SnukItem *item = snuk_item_parse(parser);
-            switch (item->type) {
-                case SNUK_ITEM_VAR_DECL:
-                case SNUK_ITEM_CONST_DECL:
-                    build_type_type(parser, type_type, item->var->type);
-                    break;
-                case SNUK_ITEM_EXPR:
-                    switch (item->expr->type) {
-                        case SNUK_EXPR_FN:
-                            build_type_type(parser, type_type, item->expr->fn_expr.type);
-                            break;
-                        case SNUK_EXPR_TYPE:
-                            build_type_type(parser, type_type, item->expr->type_expr.type);
-                            break;
-                        default:
-                            SNUK_SHOULD_NOT_REACH_HERE;
-                    }
-                    break;
-                default:
-                    SNUK_SHOULD_NOT_REACH_HERE;
-                    break;
-            }
             snuk_darray_push(&members, item);
         } else {
             parser_error(parser, "unexpected token");

--- a/src/parser/snuk_item.c
+++ b/src/parser/snuk_item.c
@@ -147,25 +147,11 @@ static SnukItem *parse_interface_item(SnukParser *parser) {
     parser_expect(parser, SNUK_TOKEN_IDENTIFIER, "expected interface name");
     SnukStringView name = parser->previous.string_literal;
 
-    SnukItem **members = snuk_darray_create(SnukItem *, parser->allocator);
-    parser_expect(parser, SNUK_TOKEN_LBRACE, "expected '{'");
-    while (!parser_match(parser, SNUK_TOKEN_RBRACE) && parser->current.type != SNUK_TOKEN_EOF) {
-        if (parser_check(parser, SNUK_TOKEN_VAR) || parser_check(parser, SNUK_TOKEN_CONST)) {
-            SnukItem *item = snuk_item_parse(parser);
-            snuk_darray_push(&members, item);
-        } else {
-            parser_error(parser, "unexpected token");
-        }
-    }
-
-    if (parser->previous.type != SNUK_TOKEN_RBRACE) {
-        parser_error(parser, "expected '}'");
-        return NULL;
-    }
+    SnukType *type = snuk_type_parse_interface(parser);
 
     parser_expect_item_end(parser);
 
-    return build_interface_item(parser, name, members);
+    return build_interface_item(parser, name, type);
 }
 
 const char *snuk_item_type_to_string(SnukItemType type) {

--- a/src/parser/snuk_type.c
+++ b/src/parser/snuk_type.c
@@ -1,32 +1,40 @@
 #include "snuk/parser/snuk_type.h"
 
+#include "snuk/parser/snuk_var.h"
+
 SnukType any_type = {
     .type = TYPE_ANY,
 };
 
-SnukType *snuk_type_parse(SnukParser *parser) {
-    if (parser_match(parser, SNUK_TOKEN_TYPE)) {
-        // type <type>
-        if (parser_match(parser, SNUK_TOKEN_IDENTIFIER))
-            return build_named_type(parser, parser->previous.string_literal);
+SnukType type_type = {
+    .type = TYPE_TYPE,
+};
 
-        // type {<type>; <type>}
-        SnukType *type = build_type_type(parser, NULL, NULL);
-        parser_expect(parser, SNUK_TOKEN_LBRACE, "expected '{'");
-        while (!parser_match(parser, SNUK_TOKEN_RBRACE) && parser->current.type != SNUK_TOKEN_EOF) {
-            SnukType *member_type = snuk_type_parse(parser);
-            type = build_type_type(parser, type, member_type);
-            if (!parser_check(parser, SNUK_TOKEN_RBRACE)) parser_expect_item_end(parser);
-        }
+SnukType *snuk_type_parse_interface(SnukParser *parser) {
+    SnukType *type = build_interface_type(parser, NULL, NULL);
+    parser_expect(parser, SNUK_TOKEN_LBRACE, "expected '{'");
 
-        if (parser->previous.type != SNUK_TOKEN_RBRACE) {
-            parser_error(parser, "expected '}'");
+    while (!parser_match(parser, SNUK_TOKEN_RBRACE) && parser->current.type != SNUK_TOKEN_EOF) {
+        if (!parser_match(parser, SNUK_TOKEN_VAR) && !parser_match(parser, SNUK_TOKEN_CONST)) {
+            parser_error(parser, "expected var or const");
             return NULL;
         }
 
-        return type;
+        SnukVar *var = snuk_var_parse(parser, false);
+        parser_expect_item_end(parser);
+        if (var->value) parser_error(parser, "interface members should not have values");
+        type = build_interface_type(parser, type, var);
     }
 
+    if (parser->previous.type != SNUK_TOKEN_RBRACE) {
+        parser_error(parser, "expected '}'");
+        return NULL;
+    }
+
+    return type;
+}
+
+SnukType *snuk_type_parse(SnukParser *parser) {
     if (parser_match(parser, SNUK_TOKEN_FN)) {
         SnukType *type = build_fn_type(parser, NULL, NULL, NULL);
         parser_expect(parser, SNUK_TOKEN_LPAREN, "exptected '('");
@@ -50,9 +58,12 @@ SnukType *snuk_type_parse(SnukParser *parser) {
         return type;
     }
 
+    if (parser_match(parser, SNUK_TOKEN_INTERFACE)) return snuk_type_parse_interface(parser);
+
+    if (parser_match(parser, SNUK_TOKEN_TYPE)) return build_type_type(parser);
     if (parser_match(parser, SNUK_TOKEN_ANY)) return build_any_type(parser);
 
-    parser_expect(parser, SNUK_TOKEN_IDENTIFIER, "unexpected type");
+    parser_expect(parser, SNUK_TOKEN_IDENTIFIER, "expected a type name");
 
     return build_named_type(parser, parser->previous.string_literal);
 }
@@ -83,4 +94,49 @@ void snuk_type_log(SnukType *type) {
         default:
             break;
     }
+}
+
+bool snuk_type_equal(SnukType *type1, SnukType *type2) {
+    if (type1->type != type2->type) return false;
+
+    uint64_t count1;
+    uint64_t count2;
+    switch (type1->type) {
+        case TYPE_ANY:
+        case TYPE_TYPE:
+            return true;
+
+        case TYPE_NAMED:
+            return snuk_string_view_equal(type1->name, type2->name);
+
+        case TYPE_FN:
+            if (!snuk_type_equal(type1->fn.return_type, type2->fn.return_type)) return false;
+
+            count1 = snuk_darray_get_length(type1->fn.param_types);
+            count2 = snuk_darray_get_length(type2->fn.param_types);
+            if (count1 != count2) return false;
+
+            for (uint64_t i = 0; i < count1; ++i)
+                if (!snuk_type_equal(type1->fn.param_types[i], type2->fn.param_types[i]))
+                    return false;
+            return true;
+
+        case TYPE_INTERFACE:
+            count1 = snuk_darray_get_length(type1->members);
+            count2 = snuk_darray_get_length(type2->members);
+            if (count1 != count2) return false;
+            for (uint64_t i = 0; i < count1; ++i) {
+                if (!snuk_string_view_equal(type1->members[i]->name, type2->members[i]->name))
+                    return false;
+                if (!snuk_type_equal(type1->members[i]->type, type2->members[i]->type))
+                    return false;
+            }
+
+            return true;
+
+        default:
+            SNUK_SHOULD_NOT_REACH_HERE;
+            break;
+    }
+    return false;
 }

--- a/tests/type.snuk
+++ b/tests/type.snuk
@@ -17,8 +17,8 @@ type Square { // type definition syntax sugar
 // type instance
 var square: Square = type Square {top_left: type Point {x: 10; y: 20;}; width: 20; height: 20}
 
-// type annotation can have type of the form "type <type>" like "type Square"
-var square2: type Square = type Square {
+// Type annotation
+var square2: Square = type Square {
     top_left: type Point {
         x: 10
         y: 20

--- a/tests/types.snuk
+++ b/tests/types.snuk
@@ -8,10 +8,7 @@ var transform: fn(float) -> float
 var n: fn()
 var o: fn(int, any)
 var z2: fn(any, fn ()) -> fn (int) -> int
-var something: type {int; float}
-var anotherthing: type {
-    int
-    fn() -> float
-}
+var something: type
+var anotherthing: type = type SomeType{var x: int}
 x = "string" // can do this because x is of type any
 // z = "string" // can't do this because z is of type int


### PR DESCRIPTION
Removed the type annotation of type {types...} format Instead of that interfaces is there
Interfaces are just type annotation now
All type checking are corrected
Named types cannot have `type` keyword before them.

## What does this PR do?

<!-- one or two sentences -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation
- [ ] `refactor` — no behavior change
- [ ] `chore` — build / tooling
- [ ] `perf` — performance
- [ ] `test` — tests only

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [x] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

<!-- optional — edge cases, open questions, related issues -->
