### PR TITLE
docs: sync documentation with current language features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Snuk uses [Semantic Versioning](https://semver.org/).
 - `extend` — add members to existing types without modifying definition
   - Works on built-in types (`int`, `float`, `bool`, `str`) and user types
   - Takes same declarations as `type {}` body
+- `print` keyword — outputs values, accepts multiple arguments with commas
 - Comment trivia — leading and trailing comments attached to tokens
 - Optional semicolons — newlines work as separators inside `{}`
 

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -31,7 +31,6 @@ Nothing here is guaranteed — this is a thinking space, not a roadmap.
 
 ## Platform
 
-- Windows, Linux, macOS build verification
 - Pre-built binaries for major platforms
 - Package manager integration
 

--- a/README.md
+++ b/README.md
@@ -317,15 +317,26 @@ print_area(type Circle { radius: 7.0 })
 | `float` | `3.14`, `-0.5` |
 | `bool` | `true`, `false` |
 | `str` | `"hello"`, `'world'` |
-| `null` | `null` |
 | `fn` | `fn(a, b) { }` |
 | `type` | `type { }` |
-| `list` | `[1, 2, 3]` *(not yet implemented)* |
+| `list` | `[1, 2, 3]` *(parsed, runtime returns `null`)* |
+
+`null` is a special value — **not a type**. It cannot be extended.
+Falsy values: `0`, `0.0`, `false`, `""`, `null` — everything else is truthy.
 
 ### Built-in methods
 
-All primitive types have conversion methods callable directly on literals.
-Falsy values: `0`, `0.0`, `false`, `""`, `null` — everything else is truthy.
+All primitive types (`int`, `float`, `bool`, `str`) expose a mutable
+`.value` field of type `any` that holds the underlying value. This is
+accessible when extending a type:
+
+```snuk
+extend int {
+    fn is_even() { value % 2 == 0 }
+}
+```
+
+Conversion methods are callable directly on literals:
 
 ```snuk
 100.to_float()          // 100.0
@@ -341,6 +352,17 @@ Falsy values: `0`, `0.0`, `false`, `""`, `null` — everything else is truthy.
 "hello".get(start=1, len=3)   // "ell"
 "hello".get(len=3)            // "hel"
 // returns null on out of bounds
+```
+
+### Print
+
+`print` is a built-in keyword that outputs values. It accepts any
+number of arguments separated by commas:
+
+```snuk
+print "hello"              // hello
+print 1 + 2                // 3
+print "x =", x             // x = 10
 ```
 
 ### Operators

--- a/docs/snuk_language.snuk
+++ b/docs/snuk_language.snuk
@@ -134,6 +134,9 @@ const APP = "snuk"
 // Built-in types can be extended:
 //   extend int { fn is_even() { value % 2 == 0 } }
 //   10.is_even()    // true
+//
+// `nan` and `inf` literal tokens exist in the lexer but are
+// not yet functional — they will produce a parse error.
 
 
 // ── 4. OPERATORS ─────────────────────────────────────────────
@@ -619,7 +622,19 @@ extend Point {
 
 // ── 10. BUILT-IN METHODS ─────────────────────────────────────
 
-// All primitive types (int, float, bool, str) have:
+// All primitive types (int, float, bool, str) expose a mutable
+// `.value` member of type `any` that holds the underlying value:
+//
+//   type int n = { value: 42 }
+//   n.value       // 42 (any)
+//
+// This is useful when extending a type:
+//
+//   extend int {
+//       fn is_even() { value % 2 == 0 }
+//   }
+//
+// Conversion methods:
 //
 //   .to_int()    → int    — converts to int,   null on failure
 //   .to_float()  → float  — converts to float, null on failure
@@ -669,12 +684,16 @@ var ss6: str = sv.get(start=1)         // "ello"
 
 // ── 11. PRINT ────────────────────────────────────────────────
 
+// `print` is a built-in keyword that outputs values.
+// It accepts any number of arguments separated by commas.
+
 print "hello"           // hello
 print 42                // 42
 print true              // true
 print null              // null
 print add               // fn(a, b)
 print Point             // type { px, py }
+print "x =", x          // x = 10
 
 
 // ── 12. COMPLETE EXAMPLES ────────────────────────────────────


### PR DESCRIPTION
Updates across README.md, CHANGELOG.md, docs/snuk_language.snuk, and FUTURE.md to accurately reflect the current state of the language.

### Changes
- **README.md**: Removed `null` from built-in types table (special value, not a type), clarified list status, documented `.value` member on primitives, added `print` keyword section
- **CHANGELOG.md**: Added `print` keyword to Language section
- **docs/snuk_language.snuk**: Added `.value` member explanation, `nan`/`inf` note, formalized `print` keyword docs
- **FUTURE.md**: Removed completed CI build verification entry