### PR TITLE
fix(type): make TYPE_ANY compatible with all types in snuk_type_equal

### DIFF
--- a/src/parser/snuk_type.c
+++ b/src/parser/snuk_type.c
@@ -97,6 +97,7 @@ void snuk_type_log(SnukType *type) {
 }
 
 bool snuk_type_equal(SnukType *type1, SnukType *type2) {
+    if (type1->type == TYPE_ANY || type2->type == TYPE_ANY) return true;
     if (type1->type != type2->type) return false;
 
     uint64_t count1;

--- a/tests/interface_type_any.snuk
+++ b/tests/interface_type_any.snuk
@@ -1,0 +1,29 @@
+// Test: interface satisfaction with untyped methods (any return type)
+// This was broken before fix/interface-type-any-compatibility
+interface HasArea {
+    var area: fn() -> float
+}
+
+type Rect {
+    var w: float = 0.0
+    var h: float = 0.0
+    // no return type annotation — return type is `any`
+    fn area() { w * h }
+}
+
+fn print_area(s: HasArea) {
+    print s.area()
+}
+
+// typed instantiation
+type Rect r = { w: 10.0; h: 20.0 }
+print_area(r)
+
+// untyped method matched against interface fn() -> float
+type Square {
+    var side: float = 5.0
+    fn area() { side * side }
+    fn describe() { "Square" }
+}
+
+print_area(type Square { side: 4.0 })


### PR DESCRIPTION
## What does this PR do?

Fixes interface satisfaction for methods without explicit return type annotations. Previously, a method with return type `any` (the default when no annotation is given) could not satisfy an interface method declared with a concrete return type like `fn() -> float`.

The root cause: `snuk_type_equal` required exact type variant match, so `TYPE_ANY` vs `TYPE_NAMED("float")` failed before reaching any comparison logic.

## Type of change

- [x] `fix` — bug fix

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [x] New behavior covered by a test file in `tests/`
- [x] Commits follow conventional commit format

## Anything reviewers should know?

The fix is a single line at the top of `snuk_type_equal`: if either type is `TYPE_ANY`, return true immediately. This matches gradual typing semantics where `any` (the dynamic/untyped type) is compatible with everything.