### PR TITLE
docs: update docs to reflect type annotation rejects type values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Snuk uses [Semantic Versioning](https://semver.org/).
 - `type Name {}` as syntax sugar for `var Name = type {}`
 - Four type instantiation forms
 - Type annotation using type name directly — `var x: Point`
-- Annotating with a type name accepts the type itself OR its instances
+- Annotating with a type name accepts instances only, not the type itself
 - Nested type instantiation
 - Methods with direct field access via instance scope resolution
 - `self` available in methods for explicit instance reference

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ var name: str = "snuk"
 const MAX = 100
 
 // user-defined type annotation — just the name
-var p: Point        // accepts Point type or Point instances
+var p: Point        // accepts Point instances only, not the type itself
 
 // "type" annotation — accepts any type value, rejects instances
 var T: type = Point

--- a/docs/snuk_language.snuk
+++ b/docs/snuk_language.snuk
@@ -85,9 +85,9 @@ type SomeType {
     var sy = 0
 }
 
-// annotate with a type name — accepts the type itself OR its instances
+// annotate with a type name — accepts instances only, not the type itself
 var pt1: SomeType = type SomeType { sx: 0; sy: 0 }   // instance — valid
-var pt2: SomeType = SomeType                          // the type itself — valid
+// var pt2: SomeType = SomeType                       // runtime error — type annotation rejects type values
 
 // "type" annotation — accepts any type value, rejects instances
 var T: type = SomeType          // valid — SomeType is a type value
@@ -424,7 +424,7 @@ var Point2 = type {
 var at = type { var z = 0 }
 
 // type annotation — just the name, no "type" keyword needed
-var annpt: Point   // accepts Point type or Point instances
+var annpt: Point   // accepts Point instances only, not the type itself
 
 // type factory — types capture enclosing scope (closures)
 // closure scope is lower priority than instance scope at call time


### PR DESCRIPTION
## What does this PR do?

Updates documentation to reflect that annotating with a type name no longer accepts the type itself — a change introduced in commit a8c7e7d.

## Type of change

- [x] `docs` — documentation

## Checklist

- [x] Branch cut from `dev`
- [x] Builds without warnings (`-Wall -Wextra`)
- [x] Existing test files still pass
- [x] Commits follow conventional commit format