### PR TITLE
fix(interpreter): prioritize locals over instance fields, propagate instance for bare method calls

### DIFF
--- a/demo/hello.snuk
+++ b/demo/hello.snuk
@@ -1,0 +1,178 @@
+//
+// Snuk Text Adventure
+// A simple text adventure game with rooms, items, and locked doors.
+// Snuk limitation: print on instances with circular references crashes,
+// so we access specific fields rather than printing instances directly.
+//
+
+
+// ── Room type ──
+
+type Room {
+    var name: str = ""
+    var description: str = ""
+    var north = null
+    var south = null
+    var east = null
+    var west = null
+    var has_key = false
+    var has_lantern = false
+    var has_treasure = false
+    var locked = false
+}
+
+
+// ── Player type ──
+
+type Player {
+    var current_room = null
+    var has_key = false
+    var has_lantern = false
+    var has_treasure = false
+    var moves = 0
+    var won = false
+
+    fn look() {
+        print ""
+        print "== " + current_room.name + " =="
+        print current_room.description
+
+        if current_room.has_key and not has_key {
+            print "  * a rusty key"
+        }
+        if current_room.has_lantern and not has_lantern {
+            print "  * a lantern"
+        }
+        if current_room.has_treasure and not has_treasure {
+            print "  * a treasure chest!"
+        }
+
+        var exits = ""
+        if current_room.north != null { exits = exits + "north " }
+        if current_room.south != null { exits = exits + "south " }
+        if current_room.east  != null { exits = exits + "east " }
+        if current_room.west  != null { exits = exits + "west " }
+        if exits != "" { print "Exits: " + exits }
+    }
+
+    fn go(dir) {
+        var next = null
+        if dir == "n" { next = current_room.north }
+        if dir == "s" { next = current_room.south }
+        if dir == "e" { next = current_room.east }
+        if dir == "w" { next = current_room.west }
+
+        if next == null {
+            print "You can't go that way."
+            return false
+        }
+
+        if next.locked {
+            if has_key {
+                print "You unlock the door with the rusty key."
+                next.locked = false
+            } else {
+                print "The door is locked. You need a key."
+                return false
+            }
+        }
+
+        self.current_room = next
+        self.moves = moves + 1
+        look()
+        true
+    }
+
+    fn take(item) {
+        if item == "key" and current_room.has_key and not has_key {
+            self.has_key = true
+            print "You pick up the rusty key."
+            return true
+        }
+
+        if item == "lantern" and current_room.has_lantern and not has_lantern {
+            self.has_lantern = true
+            print "You take the lantern."
+            return true
+        }
+
+        if item == "treasure" and current_room.has_treasure and not has_treasure {
+            self.has_treasure = true
+            self.won = true
+            print ""
+            print "********************************"
+            print "  YOU FOUND THE TREASURE!"
+            print "  Completed in " + moves.to_str() + " moves!"
+            print "********************************"
+            print ""
+            return true
+        }
+
+        print "There's no " + item + " here."
+        false
+    }
+
+    fn inventory() {
+        print ""
+        print "You are carrying:"
+        if has_key     { print "  - a rusty key" }
+        if has_lantern { print "  - a lantern" }
+        if not has_key and not has_lantern { print "  (nothing)" }
+    }
+}
+
+
+// ── Build the world ──
+
+var hall    = type Room { name: "Entrance Hall"; description: "A dusty hall with old portraits on the walls." }
+var garden  = type Room { name: "Garden";         description: "A peaceful garden with overgrown paths." }
+var kitchen = type Room { name: "Kitchen";        description: "A cold, dark kitchen. Something smells odd." }
+var library = type Room { name: "Library";        description: "Bookshelves line every wall." }
+var dungeon = type Room { name: "Dungeon";        description: "A damp stone corridor. Torches flicker."; locked: true }
+var treasure_room = type Room { name: "Treasure Room"; description: "Gold and jewels glitter in the torchlight!" }
+
+hall.north = garden
+hall.south = kitchen
+hall.east  = library
+garden.south = hall
+kitchen.north = hall
+library.west = hall
+
+kitchen.south = dungeon
+dungeon.north = kitchen
+dungeon.south = treasure_room
+treasure_room.north = dungeon
+
+hall.has_lantern = true
+kitchen.has_key = true
+treasure_room.has_treasure = true
+
+
+// ── Scripted play-through ──
+
+fn play_through() {
+    var player = type Player { current_room: hall }
+
+    player.look()
+    print ""
+    print "--- The adventure begins! ---"
+
+    player.go("n")
+    player.go("s")
+    player.go("e")
+    player.go("w")
+    player.go("s")
+    print "--- A key catches your eye. ---"
+    player.take("key")
+    player.go("s")
+    player.go("s")
+    player.inventory()
+    player.take("treasure")
+
+    print ""
+    print "Final stats:"
+    print "  Moves: " + player.moves.to_str()
+    print "  Treasure: " + player.won.to_str()
+}
+
+play_through()

--- a/include/snuk/interpreter/interpreter_helper.h
+++ b/include/snuk/interpreter/interpreter_helper.h
@@ -97,16 +97,42 @@ SNUK_INLINE bool interpreter_set_member(
  *
  * Do not use the returned env to set value
  */
-SNUK_INLINE SnukEnv *interpreter_lookup(SnukInterpreter *intpret, SnukStringView name, bool *locked) {
+SNUK_INLINE SnukEnv *interpreter_lookup(
+    SnukInterpreter *intpret, SnukStringView name, bool *locked, bool *found_in_instance) {
     SnukEnv *env = NULL;
-    if (intpret->instance) {
-        SnukEnv *self_env = snuk_scope_lookup(intpret->instance, self_str, locked);
-        if (!self_env) return NULL;
-        env = interpreter_get_member_env(intpret, self_env->value, name, locked);
-        if (env) return env;
+    bool is_locked = false;
+
+    // Walk scope chain: locals and params (non-locked) take priority over instance fields.
+    // If found in a locked scope (type scope), defer to instance path for possible
+    // shadow copy, then fall back to the type scope default.
+    env = snuk_scope_lookup_recursive(intpret->current, name, &is_locked);
+
+    if (env && !is_locked) {
+        // Found in a non-locked scope — local, param, or global
+        if (found_in_instance) *found_in_instance = false;
+        return env;
     }
-    if (!env) env = snuk_scope_lookup_recursive(intpret->current, name, locked);
-    return env;
+
+    // Check instance fields (instance closure first, then type scope defaults)
+    if (intpret->instance) {
+        SnukEnv *self_env = snuk_scope_lookup(intpret->instance, self_str, NULL);
+        if (!self_env) return NULL;
+        SnukEnv *member_env = interpreter_get_member_env(intpret, self_env->value, name, locked);
+        if (member_env) {
+            if (found_in_instance) *found_in_instance = true;
+            return member_env;
+        }
+    }
+
+    // Return the type scope value as fallback (for fields defined in type but not
+    // yet shadow-copied to the instance closure)
+    if (env) {
+        if (locked) *locked = is_locked;
+        if (found_in_instance) *found_in_instance = intpret->instance != NULL;
+        return env;
+    }
+
+    return NULL;
 }
 
 SNUK_INLINE void interpreter_trash(SnukInterpreter *intpret, SnukValue value) {

--- a/include/snuk/interpreter/interpreter_helper.h
+++ b/include/snuk/interpreter/interpreter_helper.h
@@ -110,6 +110,7 @@ SNUK_INLINE SnukEnv *interpreter_lookup(
     if (env && !is_locked) {
         // Found in a non-locked scope — local, param, or global
         if (found_in_instance) *found_in_instance = false;
+        if (locked) *locked = false;
         return env;
     }
 

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -105,7 +105,7 @@ bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value
         if (value.type == snuk_builtins_get_value_type(type->name)) return true;
         if (value.type != SNUK_VALUE_TYPE_INST) return false;
 
-        SnukEnv *env = interpreter_lookup(intpret, type->name, NULL);
+        SnukEnv *env = interpreter_lookup(intpret, type->name, NULL, NULL);
         if (!env) return false;
 
         if (env->value.type == SNUK_VALUE_INTERFACE)
@@ -163,9 +163,14 @@ bool snuk_interpreter_value_is_of_type(SnukInterpreter *intpret, SnukValue value
 }
 
 SnukValue snuk_interpreter_get_env(SnukInterpreter *intpret, SnukStringView name) {
-    SnukEnv *env = interpreter_lookup(intpret, name, NULL);
+    bool found_in_instance = false;
+    SnukEnv *env = interpreter_lookup(intpret, name, NULL, &found_in_instance);
     if (!env) return (SnukValue){.type = SNUK_VALUE_UNKOWN};
-    return snuk_value_copy(env->value);
+    SnukValue value = snuk_value_copy(env->value);
+    if (found_in_instance && value.type == SNUK_VALUE_FN && !value.fn_value.instance && intpret->instance) {
+        value.fn_value.instance = snuk_ref_counter_retain_weak(intpret->instance);
+    }
+    return value;
 }
 
 bool snuk_interpreter_set_env(SnukInterpreter *intpret, SnukStringView name, SnukValue value) {
@@ -180,7 +185,7 @@ bool snuk_interpreter_set_env(SnukInterpreter *intpret, SnukStringView name, Snu
         // env doesn't belong to the type or type's instance
     }
 
-    env = interpreter_lookup(intpret, name, &locked);
+    env = interpreter_lookup(intpret, name, &locked, NULL);
     if (!env) return false;
     if (locked) return false;
     if (!snuk_interpreter_value_is_of_type(intpret, value, env->type)) return false;

--- a/src/interpreter/native.c
+++ b/src/interpreter/native.c
@@ -191,7 +191,7 @@ SnukValue snuk_native_create_fn(SnukInterpreter *intpret, SnukParameter *params,
 
 SnukValue snuk_native_create_inst(
     SnukInterpreter *intpret, SnukType *type, SnukTypeMember *members, uint64_t count, bool weak_ref) {
-    SnukEnv *env = interpreter_lookup(intpret, type->name, NULL);
+    SnukEnv *env = interpreter_lookup(intpret, type->name, NULL, NULL);
     if (env->value.type != SNUK_VALUE_TYPE) return (SnukValue){.type = SNUK_VALUE_UNKOWN};
 
     interpreter_push_scope(intpret);


### PR DESCRIPTION
## Summary

Reorders `interpreter_lookup` to check scope chain first (locals/params) before instance fields, so locals correctly shadow instance fields.

Adds `found_in_instance` tracking to `interpreter_lookup`, used in `snuk_interpreter_get_env` to propagate the current instance to methods resolved via self. This fixes nested method calls via bare identifiers (e.g., `look()` inside `go()`) where the function from the type scope lacked an instance pointer.

## Changes

- `include/snuk/interpreter/interpreter_helper.h`: Reordered lookup priority, added `found_in_instance` parameter
- `src/interpreter/interpreter.c`: Instance propagation in `snuk_interpreter_get_env`, updated callers
- `src/interpreter/native.c`: Updated caller
- `demo/hello.snuk`: `go()` calls `look()` internally again (workaround no longer needed)

## Tests

All 21 integration tests pass. Demo runs end-to-end successfully.