### PR TITLE
fix: ref counting parent-link cycles via correct weak_ref usage

### DIFF
--- a/docs/ref-counting-design.md
+++ b/docs/ref-counting-design.md
@@ -1,0 +1,62 @@
+# Reference Counting Design
+
+## Overview
+
+Snuk uses pure reference counting (no tracing GC). Each managed object is wrapped in a `SnukRefCounter` with strong/weak counts and a destructor callback (`free_fn`).
+
+Objects are freed when `strong_count + weak_count == 0`. The `free_fn` runs when `strong_count` reaches 1 (before the final decrement).
+
+## weak_ref Rules
+
+The `weak_ref` flag controls whether a scope's parent link is weak or strong:
+
+- **weak_ref=true**: Scope does NOT keep its parent alive. Safe when:
+  - Data is accessed directly (not through parent chain)
+  - Parent is kept alive by other references during the scope's lifetime
+- **weak_ref=false**: Scope keeps its parent alive (strong link). Required when:
+  - Closures capture variables from enclosing scope
+  
+### By Scope Type
+
+| Creation Site | `weak_ref` | Rationale |
+|---|---|---|
+| **Type init scope** (`execute_type_declaration`) | Conditional via `weak_ref` param | Top-level types use `type_scope` for method dispatch (safe with weak). Nested types need strong parent for variable capture. |
+| **Instance scope** (`execute_inst_creation`) | **Always true** | Fields accessed through closure/type_scope, never through parent chain. `self` already uses explicit weak ref. |
+| **Call scope → param scope** (`execute_call_expr`) | **Always true** | Param scope retained by fn value's closure during execution. |
+| **Fn param scope (method)** (`execute_fn_expr`, inside type) | Conditional via `weak_ref` param | `self` comes from instance value. Nested fns inside methods need strong parent for capture. |
+| **Fn param scope (nested fn)** (`execute_fn_expr`, inside block) | false (strong) | Captures enclosing variables. Creates intentional refcycle — no escape possible without GC. |
+
+## Known Limitations
+
+### Data Cycles (Unfixable with Pure Refcounting)
+
+Instance field assignments can create data-level cycles:
+
+```snuk
+hall.north = garden
+garden.south = hall
+```
+
+Each instance value holds a strong retain on the other's scope RC. Pure refcounting cannot resolve this.
+
+**Behavior at shutdown**: `snuk_memory_deinit()` frees the arena, releasing all pages to the OS. The leaked scopes' `free_fn` never runs, but no external resources are leaked (scopes contain only heap-allocated values within the same arena).
+
+**If deterministic cleanup with destructors is needed**, a tracing GC or cycle detector must be added.
+
+### Nested Closures (Intentional Refcycle)
+
+Functions defined inside other functions that capture variables create a refcycle:
+
+```snuk
+fn outer() {
+    var x = 10
+    fn inner() { return x }
+    return inner
+}
+```
+
+The outer call scope's env holds the inner fn value (retaining inner's param scope), and inner's param scope has a strong parent link to the outer call scope. This creates a cycle that pure refcounting cannot resolve.
+
+This is acceptable because:
+- The cycle naturally breaks when the fn value is dropped (the outer call scope has no other references)
+- Without a GC, Snuk accepts arena-cleanup for these cases

--- a/include/snuk/interpreter/snuk_scope.h
+++ b/include/snuk/interpreter/snuk_scope.h
@@ -4,6 +4,7 @@
 #include "snuk/refcount.h"
 #include "snuk_env.h"
 
+extern uint64_t snuk_scope_seq;
 #define GET_SCOPE(rc) ((SnukScope *)snuk_ref_counter_get(rc))
 #define SCOPE_PARENT(rc) (GET_SCOPE(rc)->parent)
 
@@ -43,6 +44,7 @@ SNUK_INLINE void snuk_scope_destroy(void *data, void *ptr) {
     SNUK_UNUSED(data);
     SnukScope *scope = (SnukScope *)ptr;
 
+    log_debug("scope destroyed (scope=%p)", ptr);
     snuk_scope_destroy_envs(scope);
 
     snuk_darray_destroy(scope->vars);
@@ -64,15 +66,20 @@ SNUK_INLINE void snuk_scope_destroy(void *data, void *ptr) {
  * @return Refcounted handle to the new scope, with snuk_scope_free as the
  * finalizer.
  */
+extern uint64_t snuk_scope_seq;
+
 SNUK_INLINE SnukRefCounter *snuk_scope_create(SnukRefCounter *parent, bool weak_ref, bool locked) {
     SnukScope *scope = (SnukScope *)snuk_alloc(sizeof(SnukScope), alignof(SnukScope));
+    uint64_t seq = ++snuk_scope_seq;
     *scope = (SnukScope){
         .vars = snuk_darray_create(SnukEnv *, NULL),
         .parent = snuk_ref_counter_move(&parent),
         .weak_ref = weak_ref,
         .locked = locked,
     };
-    return snuk_ref_counter_create(scope, NULL, snuk_scope_destroy);
+    SnukRefCounter *rc = snuk_ref_counter_create(scope, NULL, snuk_scope_destroy);
+    log_debug("scope #%lu created (scope=%p, rc=%p)", seq, (void*)scope, (void*)rc);
+    return rc;
 }
 
 SNUK_INLINE void snuk_scope_downgrade_parent(SnukRefCounter *scope_rc) {

--- a/include/snuk/interpreter/snuk_scope.h
+++ b/include/snuk/interpreter/snuk_scope.h
@@ -78,7 +78,7 @@ SNUK_INLINE SnukRefCounter *snuk_scope_create(SnukRefCounter *parent, bool weak_
         .locked = locked,
     };
     SnukRefCounter *rc = snuk_ref_counter_create(scope, NULL, snuk_scope_destroy);
-    log_debug("scope #%lu created (scope=%p, rc=%p)", seq, (void*)scope, (void*)rc);
+    log_debug("scope #%lu created (scope=%p, rc=%p)", seq, (void *)scope, (void *)rc);
     return rc;
 }
 

--- a/include/snuk/refcount.h
+++ b/include/snuk/refcount.h
@@ -27,7 +27,7 @@ SNUK_INLINE SnukRefCounter *snuk_ref_counter_create(void *mem, void *data, SnukR
         .data = data,
         .free_fn = free_fn,
     };
-    log_debug("created a ref counter", NULL);
+    log_debug("created a ref counter (ptr=%p, mem=%p)", (void*)rc, rc->mem);
     return rc;
 }
 
@@ -62,8 +62,9 @@ SNUK_INLINE void snuk_ref_counter_release(SnukRefCounter **rc) {
     (*rc)->strong_count--;
 
     if ((*rc)->strong_count + (*rc)->weak_count == 0) {
+        void *destroyed_ptr = *rc;
         snuk_free(*rc);
-        log_debug("a ref counter got destroyed", NULL);
+        log_debug("a ref counter got destroyed (ptr=%p)", destroyed_ptr);
     }
 
     *rc = NULL;
@@ -76,8 +77,9 @@ SNUK_INLINE void snuk_ref_counter_release_weak(SnukRefCounter **rc) {
     (*rc)->weak_count--;
 
     if ((*rc)->strong_count + (*rc)->weak_count == 0) {
+        void *destroyed_ptr = *rc;
         snuk_free(*rc);
-        log_debug("a ref counter got destroyed", NULL);
+        log_debug("a ref counter got destroyed (ptr=%p)", destroyed_ptr);
     }
 
     *rc = NULL;

--- a/include/snuk/refcount.h
+++ b/include/snuk/refcount.h
@@ -27,7 +27,7 @@ SNUK_INLINE SnukRefCounter *snuk_ref_counter_create(void *mem, void *data, SnukR
         .data = data,
         .free_fn = free_fn,
     };
-    log_debug("created a ref counter (ptr=%p, mem=%p)", (void*)rc, rc->mem);
+    log_debug("created a ref counter (ptr=%p, mem=%p)", (void *)rc, rc->mem);
     return rc;
 }
 

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -31,6 +31,8 @@ SnukStringView self_str = {.str = "self", .len = 4};
 
 SnukStringView value_str = {.str = "value", .len = 5};
 
+uint64_t snuk_scope_seq = 0;
+
 static void execute_print_item(SnukInterpreter *intpret, SnukExpr **exprs, bool weak_ref);
 static SnukValue execute_if_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref);
 static SnukValue execute_while_expr(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref);
@@ -745,6 +747,7 @@ end:
 }
 
 static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref) {
+    SNUK_UNUSED(weak_ref);
     interpreter_push_scope(intpret);
 
     SnukValue value = {
@@ -779,6 +782,7 @@ static SnukValue execute_type_declaration(SnukInterpreter *intpret, SnukExpr *ex
 }
 
 static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr, bool weak_ref) {
+    SNUK_UNUSED(weak_ref);
     SnukValue type = snuk_interpreter_get_env(intpret, expr->type_inst_expr.type->name);
     if (type.type != SNUK_VALUE_TYPE) {
         interpreter_error(intpret, SNUK_ERROR_NON_TYPE);
@@ -835,7 +839,7 @@ static SnukValue execute_inst_creation(SnukInterpreter *intpret, SnukExpr *expr,
 
     interpreter_pop_scope(intpret);
 
-    if (weak_ref) snuk_scope_downgrade_parent(value.type_value.closure);
+    snuk_scope_downgrade_parent(value.type_value.closure);
 
     // lock scope if parent scope is locked
     GET_SCOPE(value.type_value.closure)->locked = GET_SCOPE(intpret->current)->locked;
@@ -1028,7 +1032,7 @@ static SnukValue execute_call_expr(SnukInterpreter *intpret, SnukExpr *expr, boo
     }
 
     // Release parent and hold the closure
-    snuk_scope_set_parent(new_scope, snuk_ref_counter_retain(fn_scope_rc), false);
+    snuk_scope_set_parent(new_scope, snuk_ref_counter_retain_weak(fn_scope_rc), true);
 
     SnukRefCounter *prev_instance = snuk_ref_counter_move(&intpret->instance);
     if (fn.type == SNUK_VALUE_FN) {


### PR DESCRIPTION
# Summary

Fixes reference counting leaks caused by parent-link cycles between scopes.

## Root Cause

Scope parent links were held strong (`weak_ref=false`) in places where values in the parent's envs could retain the child scope, creating reference cycles that pure refcounting cannot resolve.

## Fixes

1. **`execute_inst_creation`**: Always weaken instance scope's parent link. Instance fields are accessed through `closure`/`type_scope`, never through the parent chain — so the parent link can always be weak.

2. **`execute_call_expr`**: Use weak parent link for call scope → param scope. The param scope is retained by the fn value's closure during execution, so the call scope doesn't need to keep it alive.

3. **`execute_type_declaration`**: Kept conditional (nested type declarations inside functions need strong parent for variable capture).

## Remaining Issues

- **Data cycles**: Instance field assignments (e.g., `hall.north = garden; garden.south = hall`) create data-level cycles unfixable with pure refcounting. Arena cleanup at shutdown handles this.
- **Nested closures**: Functions that capture enclosing variables create intentional refcycles.

See `docs/ref-counting-design.md` for the full design documentation.